### PR TITLE
Go whole hog on SQL expressions

### DIFF
--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -23,7 +23,7 @@ engine = sqlalchemy.create_engine('postgres://', connect_args=config)
 def test_engine():
     assert len(engine.execute("SELECT * FROM food_inspections").fetchall()) == 966
 
-def test_simple_agg():
+def test_simple_explicit_agg():
     agg = collate.Aggregate(""" "Results" = 'Fail'""",["count"])
     st = collate.SpacetimeAggregation([agg],
         intervals = ["1 year", "2 years", "all"],
@@ -34,3 +34,13 @@ def test_simple_agg():
     for sel in st.get_queries():
         engine.execute(sel) # Just test that we can execute the query
 
+def test_simple_lazy_agg():
+    agg = collate.Aggregate(""" "Results" = 'Fail'""",["count"])
+    st = collate.SpacetimeAggregation([agg],
+        intervals = ["1 year", "2 years", "all"],
+        from_obj = 'food_inspections',
+        group_by = '"License #"',
+        dates = ['2016-08-31'],
+        date_column = '"Inspection Date"')
+    for sel in st.get_queries():
+        engine.execute(sel) # Just test that we can execute the query

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -14,6 +14,8 @@ from os import path
 
 from collate import collate
 
+import sqlalchemy.sql.expression as ex
+
 with open(path.join(path.dirname(__file__), "config/database.yml")) as f:
     config = yaml.load(f)
 engine = sqlalchemy.create_engine('postgres://', connect_args=config)
@@ -25,9 +27,10 @@ def test_simple_agg():
     agg = collate.Aggregate(""" "Results" = 'Fail'""",["count"])
     st = collate.SpacetimeAggregation([agg],
         intervals = ["1 year", "2 years", "all"],
-        from_obj = 'food_inspections',
-        group_by = '"License #"',
+        from_obj = ex.table('food_inspections'),
+        group_by = ex.column('License #'),
         dates = ['2016-08-31'],
-        date_column = '"Inspection Date"')
+        date_column = ex.column('Inspection Date'))
     for sel in st.get_queries():
         engine.execute(sel) # Just test that we can execute the query
+


### PR DESCRIPTION
Note that this is a PR to merge into @potash's sqlalchemy branch.

I really like this direction, and I think it makes sense to default to `expression.text` objects for strings.

This also removes all interpolation of strings into SQL objects… and should be more robust.