### PR TITLE
Create table as

### DIFF
--- a/collate/collate.py
+++ b/collate/collate.py
@@ -141,7 +141,7 @@ class SpacetimeAggregation(object):
         Returns: collection of aggregate column SQL strings
         """
         if interval != 'all':
-            when = "'{date}' <= {date_column} + interval '{interval}'".format(
+            when = "{date_column} >= '{date}'::date - interval '{interval}'".format(
                     interval=interval, date=date, date_column=self.date_column)
         else:
             when = None

--- a/collate/collate.py
+++ b/collate/collate.py
@@ -266,3 +266,21 @@ class SpacetimeAggregation(object):
         """
         name = "%s_%s" % (self.prefix, self.suffix)
         return "DROP TABLE IF EXISTS %s" % name
+
+    def execute(self, conn):
+        """
+
+        """
+        creates = self.get_creates()
+        drops = self.get_drops()
+        indexes = self.get_indexes()
+
+        trans = conn.begin()
+        for group in self.groups:
+            conn.execute(drops[group])
+            conn.execute(creates[group])
+            conn.execute(indexes[group])
+
+        conn.execute(self.get_drop())
+        conn.execute(self.get_create())
+        trans.commit()

--- a/collate/collate.py
+++ b/collate/collate.py
@@ -154,7 +154,7 @@ class SpacetimeAggregation(object):
         for group, intervals in self.group_intervals.items():
             queries[group] = []
             for date in self.dates:
-                columns = list(chain(*(
+                columns = [group] + list(chain(*(
                         self._get_aggregates_sql(i, date, group)
                         for i in intervals)))
                 where = ex.text("{date_column} < '{date}'".format(
@@ -205,4 +205,16 @@ class SpacetimeAggregation(object):
             drop is a raw drop table query for the corresponding table
         """
         return {group: "DROP TABLE IF EXISTS %s;" % self._get_table_name(group)
+                for group in self.groups}
+
+    def get_create_indexes(self):
+        """
+        Generate drop queries for this aggregation
+
+        Returns: a dictionary of group : index pairs where
+            group are the same keys as group_intervals
+            index is a raw create index query for the corresponding table
+        """
+        return {group: "CREATE INDEX ON %s (%s);" % 
+                (self._get_table_name(group), group)
                 for group in self.groups}

--- a/collate/collate.py
+++ b/collate/collate.py
@@ -8,8 +8,10 @@ from sqlalchemy.ext.compiler import compiles
 def make_list(a):
     return [a] if not isinstance(a, list) else a
 
+
 def make_tuple(a):
     return (a,) if not isinstance(a, tuple) else a
+
 
 def make_sql_clause(s, constructor):
     if not isinstance(s, ex.ClauseElement):
@@ -95,8 +97,8 @@ class Aggregate(object):
 
         for function, (quantity_name, quantity), order in product(
                 self.functions, self.quantities.items(), self.orders):
-            args = str.join(", ", (arg_template.format(when=when, quantity=q) 
-                    for q in make_tuple(quantity)))
+            args = str.join(", ", (arg_template.format(when=when, quantity=q)
+                                   for q in make_tuple(quantity)))
             order_clause = order_template.format(when=when, order=order)
 
             format_kwargs = dict(function=function, args=args, prefix=prefix,

--- a/collate/collate.py
+++ b/collate/collate.py
@@ -39,7 +39,7 @@ class Aggregate(object):
     """
     An object representing one or more SQL aggregate columns in a groupby
     """
-    def __init__(self, quantity, function, name=None):
+    def __init__(self, quantity, function):
         """
         Args:
             quantity: an SQL string expression for the quantity to aggregate

--- a/collate/collate.py
+++ b/collate/collate.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 from itertools import product, chain
+from functools import reduce
 import sqlalchemy.sql.expression as ex
 from sqlalchemy.ext.compiler import compiles
 

--- a/collate/collate.py
+++ b/collate/collate.py
@@ -170,11 +170,11 @@ class SpacetimeAggregation(object):
                           .group_by(gb_clause)
 
                 if 'all' not in intervals:
-                    greatest = "greatest(%s)" % str.join(",", 
-                            ["interval '%s'" % i for i in intervals])
+                    greatest = "greatest(%s)" % str.join(
+                            ",", ["interval '%s'" % i for i in intervals])
                     query = query.where(ex.text(
                         "{date_column} >= '{date}'::date - {greatest}".format(
-                            date_column=self.date_column, date=date, 
+                            date_column=self.date_column, date=date,
                             greatest=greatest)))
 
                 queries[group].append(query)

--- a/tests/initialize_db.py
+++ b/tests/initialize_db.py
@@ -12,4 +12,3 @@ with open("config/database.yml") as f:
 system("""psql -c "DROP TABLE IF EXISTS food_inspections;" """)
 system("""csvsql --no-constraints --table food_inspections < food_inspections_subset.csv | psql """)
 system("""psql -c "\copy food_inspections FROM 'food_inspections_subset.csv' WITH CSV HEADER;" """)
-system("""psql -c 'CREATE TABLE licenses AS (select \"License #\", \"Zip\" from food_inspections group by 1,2)' """)

--- a/tests/initialize_db.py
+++ b/tests/initialize_db.py
@@ -12,3 +12,4 @@ with open("config/database.yml") as f:
 system("""psql -c "DROP TABLE IF EXISTS food_inspections;" """)
 system("""csvsql --no-constraints --table food_inspections < food_inspections_subset.csv | psql """)
 system("""psql -c "\copy food_inspections FROM 'food_inspections_subset.csv' WITH CSV HEADER;" """)
+system("""psql -c 'CREATE TABLE licenses AS (select \"License #\", \"Zip\" from food_inspections group by 1,2)' """)

--- a/tests/test_collate.py
+++ b/tests/test_collate.py
@@ -9,22 +9,21 @@ Unit tests for `collate` module.
 """
 
 import pytest
-
-
 from collate import collate
 
+def test_aggregate():
+    agg = collate.Aggregate("*", "count")
+    assert str(list(agg.get_columns())[0]) == "count(*)"
 
-@pytest.fixture
-def response():
-    """Sample pytest fixture.
-    See more at: http://doc.pytest.org/en/latest/fixture.html
-    """
-    # import requests
-    # return requests.get('https://github.com/audreyr/cookiecutter-pypackage')
+def test_aggregate_when():
+    agg = collate.Aggregate("1", "count")
+    assert str(list(agg.get_columns(when="date < '2012-01-01'"))[0]) == "count(CASE WHEN date < '2012-01-01' THEN 1 END)"
 
+def test_ordered_aggregate():
+    agg = collate.Aggregate("", "mode", "x")
+    assert str(list(agg.get_columns())[0]) == "mode() WITHIN GROUP (ORDER BY x)"
 
-def test_content(response):
-    """Sample pytest test function with the pytest fixture as an argument.
-    """
-    # from bs4 import BeautifulSoup
-    # assert 'GitHub' in BeautifulSoup(response.content).title.string
+def test_ordered_aggregate_when():
+    agg = collate.Aggregate("", "mode", "x")
+    assert str(list(agg.get_columns(when="date < '2012-01-01'"))[0]) == "mode() WITHIN GROUP (ORDER BY CASE WHEN date < '2012-01-01' THEN x END)"
+

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -40,6 +40,23 @@ def test_simple_lazy_agg():
         group_intervals = {'"License #"':["1 year", "2 years", "all"]},
         dates = ['2016-08-31', '2015-08-31'],
         date_column = '"Inspection Date"')
-    for group_by, sels in st.get_selects().items():
+    for group, sels in st.get_selects().items():
         for sel in sels:
             engine.execute(sel) # Just test that we can execute the query
+
+def test_simple_creates():
+    agg = collate.Aggregate(""" "Results" = 'Fail'""",["count"])
+    st = collate.SpacetimeAggregation([agg],
+        from_obj = 'food_inspections',
+        group_intervals = {'"License #"':["1 year", "2 years", "all"]},
+        dates = ['2016-08-31', '2015-08-31'],
+        date_column = '"Inspection Date"')
+
+    creates = st.get_creates()
+    drops = st.get_drops()
+    for group in st.groups:
+        conn = engine.connect()
+        trans = conn.begin()
+        conn.execute(drops[group])
+        conn.execute(creates[group])
+        trans.commit()

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -64,7 +64,7 @@ def test_simple_creates():
         conn.execute(indexes[group])
     trans.commit()
 
-def test_simple_creates():
+def test_simple_create():
     agg = collate.Aggregate(""" "Results" = 'Fail'""",["count"])
     st = collate.SpacetimeAggregation([agg],
         from_obj = 'food_inspections',

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -83,5 +83,5 @@ def test_simple_creates():
         conn.execute(indexes[group])
 
     conn.execute(st.get_drop())
-    conn.execute(st.get_create('licenses'))
+    conn.execute(st.get_create())
     trans.commit()

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -73,15 +73,4 @@ def test_simple_create():
         dates = ['2016-08-31', '2015-08-31'],
         date_column = '"Inspection Date"')
 
-    creates, drops, indexes = st.get_creates(), st.get_drops(), st.get_indexes()
-
-    conn = engine.connect()
-    trans = conn.begin()
-    for group in st.groups:
-        conn.execute(drops[group])
-        conn.execute(creates[group])
-        conn.execute(indexes[group])
-
-    conn.execute(st.get_drop())
-    conn.execute(st.get_create())
-    trans.commit()
+    st.execute(engine.connect())

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -27,17 +27,19 @@ def test_simple_explicit_agg():
     st = collate.SpacetimeAggregation([agg],
         from_obj = ex.table('food_inspections'),
         group_intervals = {ex.column('License #') : ["1 year", "2 years", "all"]},
-        dates = ['2016-08-31'],
+        dates = ['2016-08-31', '2015-08-31'],
         date_column = '"Inspection Date"')
-    for sel in st.get_queries().values()[0]:
-        engine.execute(sel) # Just test that we can execute the query
+    for group_by, sels in st.get_selects().items():
+        for sel in sels:
+            engine.execute(sel) # Just test that we can execute the query
 
 def test_simple_lazy_agg():
     agg = collate.Aggregate(""" "Results" = 'Fail'""",["count"])
     st = collate.SpacetimeAggregation([agg],
         from_obj = 'food_inspections',
         group_intervals = {'"License #"':["1 year", "2 years", "all"]},
-        dates = ['2016-08-31'],
+        dates = ['2016-08-31', '2015-08-31'],
         date_column = '"Inspection Date"')
-    for sel in st.get_queries().values()[0]:
-        engine.execute(sel) # Just test that we can execute the query
+    for group_by, sels in st.get_selects().items():
+        for sel in sels:
+            engine.execute(sel) # Just test that we can execute the query

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -52,11 +52,11 @@ def test_simple_creates():
         dates = ['2016-08-31', '2015-08-31'],
         date_column = '"Inspection Date"')
 
-    creates = st.get_creates()
-    drops = st.get_drops()
+    creates, drops, indexes = st.get_creates(), st.get_drops(), st.get_indexes()
     for group in st.groups:
         conn = engine.connect()
         trans = conn.begin()
         conn.execute(drops[group])
         conn.execute(creates[group])
+        conn.execute(indexes[group])
         trans.commit()

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -22,7 +22,7 @@ engine = sqlalchemy.create_engine('postgres://', connect_args=config)
 def test_engine():
     assert len(engine.execute("SELECT * FROM food_inspections").fetchall()) == 966
 
-def test_simple_explicit_agg():
+def test_explicit_agg():
     agg = collate.Aggregate(""" "Results" = 'Fail'""",["count"])
     st = collate.SpacetimeAggregation([agg],
         from_obj = ex.table('food_inspections'),
@@ -34,7 +34,7 @@ def test_simple_explicit_agg():
         for sel in sels:
             engine.execute(sel) # Just test that we can execute the query
 
-def test_simple_lazy_agg():
+def test_lazy_agg():
     agg = collate.Aggregate(""" "Results" = 'Fail'""",["count"])
     st = collate.SpacetimeAggregation([agg],
         from_obj = 'food_inspections',
@@ -46,7 +46,7 @@ def test_simple_lazy_agg():
         for sel in sels:
             engine.execute(sel) # Just test that we can execute the query
 
-def test_simple_creates():
+def test_creates():
     agg = collate.Aggregate(""" "Results" = 'Fail'""",["count"])
     st = collate.SpacetimeAggregation([agg],
         from_obj = 'food_inspections',
@@ -64,7 +64,7 @@ def test_simple_creates():
         conn.execute(indexes[group])
     trans.commit()
 
-def test_simple_create():
+def test_execute():
     agg = collate.Aggregate(""" "Results" = 'Fail'""",["count"])
     st = collate.SpacetimeAggregation([agg],
         from_obj = 'food_inspections',

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -25,21 +25,19 @@ def test_engine():
 def test_simple_explicit_agg():
     agg = collate.Aggregate(""" "Results" = 'Fail'""",["count"])
     st = collate.SpacetimeAggregation([agg],
-        intervals = ["1 year", "2 years", "all"],
         from_obj = ex.table('food_inspections'),
-        group_by = ex.column('License #'),
+        group_intervals = {ex.column('License #') : ["1 year", "2 years", "all"]},
         dates = ['2016-08-31'],
         date_column = '"Inspection Date"')
-    for sel in st.get_queries():
+    for sel in st.get_queries().values()[0]:
         engine.execute(sel) # Just test that we can execute the query
 
 def test_simple_lazy_agg():
     agg = collate.Aggregate(""" "Results" = 'Fail'""",["count"])
     st = collate.SpacetimeAggregation([agg],
-        intervals = ["1 year", "2 years", "all"],
         from_obj = 'food_inspections',
-        group_by = '"License #"',
+        group_intervals = {'"License #"':["1 year", "2 years", "all"]},
         dates = ['2016-08-31'],
         date_column = '"Inspection Date"')
-    for sel in st.get_queries():
+    for sel in st.get_queries().values()[0]:
         engine.execute(sel) # Just test that we can execute the query


### PR DESCRIPTION
`SpacetimeAggregation` now handles multiple spatial groups through the `group_intervals` argument.

`SpacetimeAggregation.get_creates()` generates one create table per spatial group.

`SpacetimeAggregation.get_drops()` generates one drop table statement per spatial group.

`test_integration.py::test_simple_creates()` tests this