### PR TITLE
Allow line lengths up to 100 characters

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,7 @@ commands =
     py.test --cov=collate --basetemp={envtmpdir}
 
 [flake8]
- max-line-length = 99
+max-line-length = 99
 
 ; If you want to make tox run the tests with the same versions, create a
 ; requirements.txt with the pinned versions and uncomment the following lines:

--- a/tox.ini
+++ b/tox.ini
@@ -15,6 +15,8 @@ commands =
     pip install -U pip
     py.test --cov=collate --basetemp={envtmpdir}
 
+[flake8]
+ max-line-length = 99
 
 ; If you want to make tox run the tests with the same versions, create a
 ; requirements.txt with the pinned versions and uncomment the following lines:


### PR DESCRIPTION
PEP8 is actually flexible in this regard.  I say we still aim for 80 char width, but it's ok to go over.