### PR TITLE
insert one query at a time

### DIFF
--- a/collate/collate.py
+++ b/collate/collate.py
@@ -148,7 +148,7 @@ class SpacetimeAggregation(object):
             http://docs.sqlalchemy.org/en/latest/core/selectable.html
         """
         self.aggregates = aggregates
-        self.from_obj = make_sql_clause(from_obj, ex.table)
+        self.from_obj = make_sql_clause(from_obj, ex.text)
         self.group_intervals = group_intervals
         self.groups = group_intervals.keys()
         self.dates = dates

--- a/collate/collate.py
+++ b/collate/collate.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 from itertools import product, chain
-from functools import reduce
 import sqlalchemy.sql.expression as ex
 from sqlalchemy.ext.compiler import compiles
 
@@ -225,11 +224,9 @@ class SpacetimeAggregation(object):
         if not selects:
             selects = self.get_selects()
 
-        selects = {group: reduce(lambda s, t: s.union_all(t), sels)
-                   for group, sels in selects.items()}
-
-        return {group: CreateTableAs(self._get_table_name(group), select)
-                for group, select in selects.items()}
+        return {group: CreateTableAs(self._get_table_name(group),
+                                     iter(sels).next().limit(0))
+                for group, sels in selects.items()}
 
     def get_drops(self):
         """

--- a/collate/sql.py
+++ b/collate/sql.py
@@ -1,6 +1,7 @@
 import sqlalchemy.sql.expression as ex
 from sqlalchemy.ext.compiler import compiles
 
+
 def make_sql_clause(s, constructor):
     if not isinstance(s, ex.ClauseElement):
         return constructor(s)

--- a/collate/sql.py
+++ b/collate/sql.py
@@ -1,0 +1,42 @@
+import sqlalchemy.sql.expression as ex
+from sqlalchemy.ext.compiler import compiles
+
+def make_sql_clause(s, constructor):
+    if not isinstance(s, ex.ClauseElement):
+        return constructor(s)
+    else:
+        return s
+
+
+class CreateTableAs(ex.Executable, ex.ClauseElement):
+
+    def __init__(self, name, query):
+        self.name = name
+        self.query = query
+
+
+@compiles(CreateTableAs)
+def _create_table_as(element, compiler, **kw):
+    return "CREATE TABLE %s AS %s" % (
+        element.name,
+        compiler.process(element.query)
+    )
+
+
+class InsertFromSelect(ex.Executable, ex.ClauseElement):
+
+    def __init__(self, name, query):
+        self.name = name
+        self.query = query
+
+
+@compiles(InsertFromSelect)
+def _insert_from_select(element, compiler, **kw):
+    return "INSERT INTO %s (%s)" % (
+        element.name,
+        compiler.process(element.query)
+    )
+
+
+def to_sql_name(name):
+    return name.replace('"', '')

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -46,24 +46,6 @@ def test_lazy_agg():
         for sel in sels:
             engine.execute(sel) # Just test that we can execute the query
 
-def test_creates():
-    agg = collate.Aggregate(""" "Results" = 'Fail'""",["count"])
-    st = collate.SpacetimeAggregation([agg],
-        from_obj = 'food_inspections',
-        group_intervals = {'"License #"':["1 year", "2 years", "all"],
-                           '"Zip"' : ["1 year"]},
-        dates = ['2016-08-31', '2015-08-31'],
-        date_column = '"Inspection Date"')
-
-    creates, drops, indexes = st.get_creates(), st.get_drops(), st.get_indexes()
-    conn = engine.connect()
-    trans = conn.begin()
-    for group in st.groups:
-        conn.execute(drops[group])
-        conn.execute(creates[group])
-        conn.execute(indexes[group])
-    trans.commit()
-
 def test_execute():
     agg = collate.Aggregate(""" "Results" = 'Fail'""",["count"])
     st = collate.SpacetimeAggregation([agg],


### PR DESCRIPTION
instead of doing one big `create table as` with the selects unioned, first create the table using `create table as (... limit 0);` then insert each one individually. it uses less memory and is parallelizable.