### PR TITLE
output_date_column and tests

### DIFF
--- a/collate/collate.py
+++ b/collate/collate.py
@@ -101,6 +101,7 @@ class SpacetimeAggregation(object):
             prefix: prefix for column names, defaults to from_obj
             suffix: suffix for aggregation table, defaults to "aggregation"
             date_column: name of date column in from_obj, defaults to "date"
+            output_date_column: name of date column in aggregated output, defaults to "date"
 
         The from_obj and group arguments are passed directly to the
             SQLAlchemy Select object so could be anything supported there.

--- a/collate/collate.py
+++ b/collate/collate.py
@@ -87,7 +87,7 @@ class Aggregate(object):
 
 class SpacetimeAggregation(object):
     def __init__(self, aggregates, group_intervals, from_obj, dates,
-                 prefix=None, suffix=None, date_column=None):
+                 prefix=None, suffix=None, date_column=None, output_date_column=None):
         """
         Args:
             aggregates: collection of Aggregate objects
@@ -115,6 +115,7 @@ class SpacetimeAggregation(object):
         self.prefix = prefix if prefix else str(from_obj)
         self.suffix = suffix if suffix else "aggregation"
         self.date_column = date_column if date_column else "date"
+        self.output_date_column = output_date_column if output_date_column else "date"
 
     def _get_aggregates_sql(self, interval, date, group):
         """
@@ -152,7 +153,7 @@ class SpacetimeAggregation(object):
             for date in self.dates:
                 columns = [group,
                            ex.literal_column("'%s'::date"
-                                             % date).label("date")]
+                                             % date).label(self.output_date_column)]
                 columns += list(chain(*(self._get_aggregates_sql(
                         i, date, group) for i in intervals)))
 
@@ -242,7 +243,7 @@ class SpacetimeAggregation(object):
             index is a raw create index query for the corresponding table
         """
         return {group: "CREATE INDEX ON %s (%s, %s);" %
-                (self._get_table_name(group), group, "date")
+                (self._get_table_name(group), group, self.output_date_column)
                 for group in self.groups}
 
     def get_join_table(self):
@@ -264,11 +265,11 @@ class SpacetimeAggregation(object):
         name = "%s_%s" % (self.prefix, self.suffix)
 
         query = ("SELECT * FROM %s\n"
-                 "CROSS JOIN (select unnest('{%s}'::date[]) as date) t2\n") % (
-                join_table, str.join(',', self.dates))
+                 "CROSS JOIN (select unnest('{%s}'::date[]) as %s) t2\n") % (
+                join_table, str.join(',', self.dates), self.output_date_column)
         for group in self.groups:
-            query += "LEFT JOIN %s USING (%s, date)" % (
-                    self._get_table_name(group), group)
+            query += "LEFT JOIN %s USING (%s, %s)" % (
+                    self._get_table_name(group), group, self.output_date_column)
 
         return "CREATE TABLE %s AS (%s);" % (name, query)
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -56,3 +56,15 @@ def test_execute():
         date_column = '"inspection_date"')
 
     st.execute(engine.connect())
+
+def test_execute_output_date_column():
+    agg = collate.Aggregate("results='Fail'",["count"])
+    st = collate.SpacetimeAggregation([agg],
+        from_obj = 'food_inspections',
+        group_intervals = {'license_no':["1 year", "2 years", "all"],
+                           'zip' : ["1 year"]},
+        dates = ['2016-08-31', '2015-08-31'],
+        date_column = '"inspection_date"',
+        output_date_column = "aggregation_date")
+
+    st.execute(engine.connect())


### PR DESCRIPTION
At the request of @k1aus added an `output_date_column` argument to SpacetimeAggregation for customizing the name of the column containing the date of aggregation.