### PR TITLE
Add non-dev requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+SQLAlchemy==1.1.4


### PR DESCRIPTION
I think the only requirement we have is SQLAlchemy.  We implicitly depend on Post-gres-only features, but I don't think we actually need psycopg2 installed.