### PR TITLE
Revert "Update psycopg2 to 2.7"

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -10,7 +10,7 @@ cryptography==1.7.2
 PyYAML==3.12
 pytest==3.0.5
 SQLAlchemy==1.1.6
-psycopg2==2.7
+psycopg2==2.6.2
 csvkit==1.0.1
 codecov==2.0.5
 pytest-cov==2.4.0


### PR DESCRIPTION
Reverts dssg/collate#66. Blocked by https://github.com/psycopg/psycopg2/issues/517, which is slated to be fixed in 2.7.1.