### PR TITLE
Imputation (Closes #99)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,6 @@ services:
 addons:
   postgresql: "9.4"
 before_script:
-  - psql -U postgres -c "create extension postgis"
   - createdb test_collate
   - cp tests/config/database.yml{.travis,}
   - python tests/initialize_db.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,6 @@ before_script:
 
 env:
   - TOXENV=py35
-  - TOXENV=py27
   - TOXENV=flake8
 
 install: pip install -r requirements_dev.txt
@@ -41,4 +40,4 @@ deploy:
   true:
     tags: true
     repo: dssg/collate
-    condition: $TOXENV == py27
+    condition: $TOXENV == py35

--- a/README.rst
+++ b/README.rst
@@ -57,28 +57,33 @@ An example of an aggregate feature is the number of failed inspections. In raw S
 
 In collate, this aggregated column would be defined as::
 
-    Aggregate({"failed": "(results = 'Fail')::int"}, "sum")
+    Aggregate({"failed": "(results = 'Fail')::int"}, "sum", {'coltype':'aggregate', 'all': {'type': 'mean'}})
 
 Note that the SQL query is split into two parts: the first argument to ``Aggregate``
 is the computation to be performed and gives it a name (as a dictionary key), and
-the second argument is the reduction function to perform. Splitting the SQL like
-this makes it easy to generate lots of composable features as the outer product
-of these two lists.  For example, you may also be interested in the proportion
-of inspections that resulted in a failure in addition to the total number. This is
-easy to specify with the average value of the `failed` computation::
+the second argument is the reduction function to perform. The third argument provides
+a set of rules for how to handle imputation of null values in the resulting fields.
 
-    Aggregate({"failed": "(results = 'Fail')::int"}, ["sum","avg"])
+Splitting the SQL like this makes it easy to generate lots of composable features 
+as the outer product of these two lists.  For example, you may also be interested 
+in the proportion of inspections that resulted in a failure in addition to the 
+total number. This is easy to specify with the average value of the `failed` 
+computation::
+
+    Aggregate({"failed": "(results = 'Fail')::int"}, ["sum","avg"], {'coltype':'aggregate', 'all': {'type': 'mean'}})
 
 
 Aggregations in collate easily aggregate this single feature across different spatiotemporal groups, e.g.::
 
-    Aggregate({"failed": "(results = 'Fail')::int"}, ["sum","avg"])
+    Aggregate({"failed": "(results = 'Fail')::int"}, ["sum","avg"], {'coltype':'aggregate', 'all': {'type': 'mean'}})
     st = SpacetimeAggregation([fail],
 	                           from_obj='food_inspections',
                                groups=['license_no','zip'],
                                intervals={"license_no":["2 year", "3 year"], "zip": ["1 year"]},
                                dates=["2016-01-01", "2015-01-01"],
                                date_column="inspection_date",
+                               state_table='all_restaurants',
+                               state_group='license_no',
                                schema='test_collate')
 
 The ``SpacetimeAggregation`` object encapsulates the ``FROM`` section of the query
@@ -86,7 +91,9 @@ The ``SpacetimeAggregation`` object encapsulates the ``FROM`` section of the que
 columns.  Not only will this create information about the individual restaurants
 (grouping by ``license_no``), it also creates "neighborhood" columns that add
 information about the region in which the restaurant is operating (by grouping by
-``zip``).
+``zip``). The ``state_table`` specified here should contain the comprehensive set of
+``state_group`` entities and dates for which output should be generated for them,
+regardless if they exist in the ``from_obj``.
 
 Even more powerful is the sophisticated date range partitioning that the
 ``SpacetimeAggregation`` object provides.  It will create multiple queries in
@@ -95,16 +102,46 @@ back from either Jan 1, 2015 or Jan 1 2016. Executing this set of queries with::
 
     st.execute(engine.connect()) # with a SQLAlchemy engine object
 
-will create three new tables in the ``test_collate`` schema. The table
+will create four new tables in the ``test_collate`` schema. The table
 ``food_inspections_license_no`` will contain four feature columns for each
 license that describe the total number and proportion of failures over the past
 two or three years, with a date column that states whether it was looking
 before 2016 or 2015. Similarly, a ``food_inspections_zip`` table will have two
 feature columns for every zip code in the database, looking at the total and
 average number of failures in that neighborhood over the year prior to the date
-in the date column. Finally, the ``food_inspections_aggregate`` table joins
-these results together to make it easier to look at both neighborhood and
-restaurant-level effects for any given restaurant.
+in the date column. The ``food_inspections_aggregation`` table joins these results 
+together to make it easier to look at both neighborhood and restaurant-level 
+effects for any given restaurant. Finally, the ``food_inspections_aggregation_imputed``
+table fills in null values using the imputation rules specified in the ``Aggregate``
+constructor.
+
+Imputation Rules
+================
+
+Imputation rules should be specified in the form of a dictionary::
+
+    {
+        'coltype': 'aggregate',
+        'all': {'type': 'mean'},
+        'max': {'type': 'constant', 'value': 137}
+    }
+
+The ``coltype`` key of this dictionary must be one of ``aggregate``, ``categorical``, 
+or ``array_categorical`` and informs how the imputation rules are applied.
+
+The other keys of the dictionary are the reduction functions used by the aggregate
+(such as ``sum``, ``count``, ``avg``, etc.) or ``all`` as a catch-all. Function-specific
+rules will take precedence over the catch-all rule. The values associated with these
+keys are each a dictionary with a required ``type`` key specifying the rule type and
+other rule-specific keys.
+
+Currently available imputation rules:
+    * ``mean``: The average value of the feature (for ``SpacetimeAggregation`` the mean is taken within-date).
+    * ``constant``: Fill with a constant value from a required ``value`` parameter.
+    * ``zero``: Fill with zero.
+    * ``null_category``: Only available for categorical features. Just flag null values with the null category column.
+    * ``binary_mode``: Only available for aggregate column types. Takes the modal value for a binary feature.
+    * ``error``: Raise an exception if any null values are encountered for this feature.
 
 Outputs
 =======

--- a/README.rst
+++ b/README.rst
@@ -139,6 +139,7 @@ Currently available imputation rules:
     * ``mean``: The average value of the feature (for ``SpacetimeAggregation`` the mean is taken within-date).
     * ``constant``: Fill with a constant value from a required ``value`` parameter.
     * ``zero``: Fill with zero.
+    * ``zero_noflag``: Fill with zero without generating an "imputed" flag. This option should be used only for cases where null values are explicitly known to be zero such as absence of an entity from an events table indicating that no such event has occurred.
     * ``null_category``: Only available for categorical features. Just flag null values with the null category column.
     * ``binary_mode``: Only available for aggregate column types. Takes the modal value for a binary feature.
     * ``error``: Raise an exception if any null values are encountered for this feature.

--- a/collate/collate.py
+++ b/collate/collate.py
@@ -303,7 +303,7 @@ class Compare(Aggregate):
             for i, k in enumerate(list(d.keys())):
                 d['%s_%02d' % (k[:maxlen-3], i)] = d.pop(k)
 
-        Aggregate.__init__(self, d, function, order, imputation_rules)
+        Aggregate.__init__(self, d, function, impute_rules, order)
 
 
 class Categorical(Compare):

--- a/collate/collate.py
+++ b/collate/collate.py
@@ -670,6 +670,7 @@ class Aggregation(object):
         null_counts = list(zip(res.keys(), res.fetchone()))
         impute_cols = [col for col, val in null_counts if val > 0]
         nonimpute_cols = [col for col, val in null_counts if val == 0]
+        res.close()
 
         # sql to drop and create the imputation table
         drop_imp = self.get_drop(imputed=True)

--- a/collate/collate.py
+++ b/collate/collate.py
@@ -6,12 +6,13 @@ import re
 
 from .sql import make_sql_clause, to_sql_name, CreateTableAs, InsertFromSelect
 from .imputations import ImputeMean, ImputeConstant, ImputeZero, \
-    ImputeNullCategory, ImputeBinaryMode, ImputeError
+    ImputeZeroNoFlag, ImputeNullCategory, ImputeBinaryMode, ImputeError
 
 available_imputations = {
     'mean': ImputeMean,
     'constant': ImputeConstant,
     'zero': ImputeZero,
+    'zero_noflag': ImputeZeroNoFlag,
     'null_category': ImputeNullCategory,
     'binary_mode': ImputeBinaryMode,
     'error': ImputeError
@@ -610,7 +611,7 @@ class Aggregation(object):
                 imputer = imputer(column=col, partitionby=partitionby, **impute_rule)
 
                 query += '\n,%s' % imputer.to_sql()
-                if not imputer.catcol:
+                if not imputer.noflag:
                     # Add an imputation flag for non-categorical columns (this is handeled
                     # for categorical columns with a separate NULL category)
                     query += '\n,%s' % imputer.imputed_flag_sql()

--- a/collate/collate.py
+++ b/collate/collate.py
@@ -239,7 +239,7 @@ class Aggregate(AggregateExpression):
             # type used by the aggregate (or catch-all with 'all')
             try:
                 lkup[name] = dict(
-                    self.impute_rules.get(function, self.impute_rules['all']), 
+                    self.impute_rules.get(function) or self.impute_rules['all'], 
                     coltype=self.impute_rules['coltype']
                     )
             except KeyError as err:

--- a/collate/collate.py
+++ b/collate/collate.py
@@ -244,7 +244,7 @@ class Aggregate(AggregateExpression):
                     )
             except KeyError as err:
                 raise ValueError(
-                    "Must provide an imputation rule for every aggregation " + 
+                    "Must provide an imputation rule for every aggregation " +
                     "function (or 'all'). No rule found for %s" % name
                     ) from err
 
@@ -327,7 +327,7 @@ class Categorical(Compare):
     """
     A simple shorthand to automatically create many equality comparisons against one column
     """
-    def __init__(self, col, choices, function, impute_rules, 
+    def __init__(self, col, choices, function, impute_rules,
                  order=None, op_in_name=False, **kwargs):
         """
         Create a Compare object with an equality operator, ommitting the `=`

--- a/collate/collate.py
+++ b/collate/collate.py
@@ -226,7 +226,7 @@ class Aggregate(AggregateExpression):
 
             # requires an imputation rule defined for any function
             # type used by the aggregate
-            lkup[name] = self.impute_rules[function]
+            lkup[name] = dict(self.impute_rules[function], coltype=self.impute_rules['coltype'])
 
         return lkup
 

--- a/collate/collate.py
+++ b/collate/collate.py
@@ -226,10 +226,16 @@ class Aggregate(AggregateExpression):
 
             # requires an imputation rule defined for any function
             # type used by the aggregate (or catch-all with 'all')
-            lkup[name] = dict(
-                self.impute_rules.get(function, self.impute_rules['all']), 
-                coltype=self.impute_rules['coltype']
-                )
+            try:
+                lkup[name] = dict(
+                    self.impute_rules.get(function, self.impute_rules['all']), 
+                    coltype=self.impute_rules['coltype']
+                    )
+            except KeyError as err:
+                raise ValueError(
+                    "Must provide an imputation rule for every aggregation "+\
+                    "function (or 'all'). No rule found for %s" % name
+                    )
 
         return lkup
 

--- a/collate/collate.py
+++ b/collate/collate.py
@@ -539,7 +539,7 @@ class Aggregation(object):
         if self.schema is not None:
             return "CREATE SCHEMA IF NOT EXISTS %s" % self.schema
 
-    def find_nulls(self):
+    def find_nulls(self, imputed=False):
         """
         Generate query to count number of nulls in each column in the aggregation table
         
@@ -556,7 +556,9 @@ class Aggregation(object):
             ])
 
         return query_template.format(
-                cols=cols_sql, state_tbl=self.state_table, aggs_tbl=self.get_table_name(),
+                cols=cols_sql, 
+                state_tbl=self.state_table, 
+                aggs_tbl=self.get_table_name(imputed=imputed),
                 group=self.state_group
             )
 

--- a/collate/collate.py
+++ b/collate/collate.py
@@ -225,8 +225,11 @@ class Aggregate(AggregateExpression):
             name = name_template.format(**kwargs)
 
             # requires an imputation rule defined for any function
-            # type used by the aggregate
-            lkup[name] = dict(self.impute_rules[function], coltype=self.impute_rules['coltype'])
+            # type used by the aggregate (or catch-all with 'all')
+            lkup[name] = dict(
+                self.impute_rules.get(function, self.impute_rules['all']), 
+                coltype=self.impute_rules['coltype']
+                )
 
         return lkup
 

--- a/collate/collate.py
+++ b/collate/collate.py
@@ -235,7 +235,7 @@ class Aggregate(AggregateExpression):
                 raise ValueError(
                     "Must provide an imputation rule for every aggregation "+\
                     "function (or 'all'). No rule found for %s" % name
-                    )
+                    ) from err
 
         return lkup
 

--- a/collate/imputations.py
+++ b/collate/imputations.py
@@ -159,7 +159,7 @@ class ImputeBinaryMode(BaseImputation):
     def to_sql(self):
         sql = self._base_sql()
         return sql.format(
-            imp="""CASE WHEN AVG("%s") OVER (%s) > 0.5 THEN 1 ELSE 0 END, 0""" %\
+            imp="""CASE WHEN AVG("%s") OVER (%s) > 0.5 THEN 1 ELSE 0 END, 0""" %
                 (self.column, self.partitionby)
         )
 
@@ -179,5 +179,6 @@ class ImputeError(BaseImputation):
         )
 
     def to_sql(self):
-        raise ValueError("NULL values found in column with 'error' imputation type: %s" %\
-                        self.column)
+        raise ValueError(
+            "NULL values found in column with 'error' imputation type: %s" % self.column
+            )

--- a/collate/imputations.py
+++ b/collate/imputations.py
@@ -1,0 +1,168 @@
+
+class BaseImputation(object):
+    """Base class for various imputation methods
+    """
+    def __init__(self, column, coltype, partitionby=None, null_cat_pattern=None):
+        self.column = column
+        self.coltype = coltype
+        self.catcol = coltype in ['categorical', 'array_categorical']
+        self.partitionby = "" if partitionby is None else "PARTION BY %s" % partitionby
+        self.null_cat_pattern = '__NULL_' if null_cat_pattern is None else null_cat_pattern
+    def _base_sql(self):
+        return """COALESCE("{col}", {{imp}}) AS "{col}" """.format(col=self.column)        
+    def imputed_flag_sql(self):
+        if not self.catcol:
+            return """CASE WHEN "{col}" IS NULL THEN 1 ELSE 0 END AS "{col}_imp" """.format(
+                col=self.column
+            )
+        else:
+            # don't need to create a flag for categoricals since this is handled with the
+            # null category
+            return None
+
+
+class ImputeMean(BaseImputation):
+    """Class for mean imputation:
+
+    For aggregate features, just take the average of the column (optionally within
+    a partition, such as an as_of_date), falling back to 0 if the column is entirely
+    null within the partition.
+
+    For categorical features, we flag the NULL category column with a 1 and other 
+    columns with the mean, again falling back to 0 as necessary
+    """
+    def __init__(self, column, coltype, partitionby=None, null_cat_pattern=None, **kwargs):
+        BaseImputation.__init__(
+            self, 
+            column=column, 
+            coltype=coltype, 
+            partitionby=partitionby, 
+            null_cat_pattern=null_cat_pattern
+        )
+    def to_sql(self):
+        sql = self._base_sql()
+
+        if not self.catcol:
+            # aggregate columm
+            return sql.format(
+                imp="""AVG("%s") OVER (%s), 0""" % (self.column, self.partitionby)
+            )
+        elif self.null_cat_pattern in self.column:
+            # categorical NULL category
+            return sql.format(imp=1)
+        else:
+            # categorical
+            return sql.format(
+                imp="""AVG("%s") OVER (%s), 0""" % (self.column, self.partitionby)
+            )
+
+class ImputeConstant(BaseImputation): 
+    """Class for constant value imputation:
+
+    For aggregates, simply fill in the specified value.
+
+    For categoricals, match the value to the column name and fill in the matching
+    column with a 1 (as well as the NULL category column)
+    """
+    def __init__(self, column, coltype, value, null_cat_pattern=None, **kwargs):
+        BaseImputation.__init__(
+            self, 
+            column=column, 
+            coltype=coltype, 
+            partitionby=None, 
+            null_cat_pattern=null_cat_pattern
+        )
+        self.value = value
+    def to_sql(self):
+        sql = self._base_sql()
+
+        if not self.catcol:
+            # aggregate column
+            return sql.format(imp=self.value)
+        else:
+            # categorical column
+            return sql.format(
+                imp = 1 if self.value in self.column or self.null_cat_pattern in self.column else 0
+            )
+
+class ImputeZero(BaseImputation):
+    """Class for zero filling imputation:
+
+    Fill in the column with a 0, aside from a null category column for categorical
+    variables, which is filled with a 1
+    """
+    def __init__(self, column, coltype, null_cat_pattern=None, **kwargs):
+        BaseImputation.__init__(
+            self, 
+            column=column, 
+            coltype=coltype, 
+            partitionby=None, 
+            null_cat_pattern=null_cat_pattern
+        )
+    def to_sql(self):
+        sql = self._base_sql()
+        return sql.format(
+            imp = 1 if self.catcol and self.null_cat_pattern in self.column else 0
+        )
+
+class ImputeNullCategory(BaseImputation):
+    """Class for just using the null category for categoricals:
+
+    For a categorical feature, fill the null category with 1, all others with 0
+    (essentially the same as ImputeZero for categoricals only)
+    """
+    def __init__(self, column, coltype, null_cat_pattern=None, **kwargs):
+        BaseImputation.__init__(
+            self, 
+            column=column, 
+            coltype=coltype, 
+            partitionby=None, 
+            null_cat_pattern=null_cat_pattern
+        )
+        if not self.catcol:
+            raise ValueError('Can only use null category imputation for categorical features')
+    def to_sql(self):
+        sql = self._base_sql()
+        return sql.format(
+            imp = 1 if self.null_cat_pattern in self.column else 0
+        )
+
+class ImputeBinaryMode(BaseImputation):
+    """Class for mode imputation for binaries:
+
+    For a binary variable, fill with a 1 if the mean (potentially in some window)
+    is greater than 0.5, 0 otherwise. Note that this is not available for categoricals
+    as it does not determine the modal category, just whether a binary is over 50%.
+    """
+    def __init__(self, column, coltype, partitionby=None, **kwargs):
+        BaseImputation.__init__(
+            self, 
+            column=column, 
+            coltype=coltype, 
+            partitionby=partitionby
+        )
+        if self.catcol:
+            raise ValueError('Can only use binary mode imputation for non-categorical features')
+    def to_sql(self):
+        sql = self._base_sql()
+        return sql.format(
+            imp="""CASE WHEN AVG("%s") OVER (%s) > 0.5 THEN 1 ELSE 0 END, 0""" %\
+                (self.column, self.partitionby)
+        )
+
+class ImputeError(BaseImputation):
+    """Class for raising an exception on null:
+
+    If you expect your data to be clean, you can use this class to simply generate
+    an error if any null values are found in the data rather than continuing with
+    an imputation.
+    """
+    def __init__(self, column, coltype, **kwargs):
+        BaseImputation.__init__(
+            self, 
+            column=column, 
+            coltype=coltype
+        )
+    def to_sql(self):
+        raise ValueError("NULL values found in column with 'error' imputation type: %s" % self.column)
+

--- a/collate/imputations.py
+++ b/collate/imputations.py
@@ -6,7 +6,7 @@ class BaseImputation(object):
         self.column = column
         self.coltype = coltype
         self.catcol = coltype in ['categorical', 'array_categorical']
-        self.partitionby = "" if partitionby is None else "PARTION BY %s" % partitionby
+        self.partitionby = "" if partitionby is None else "PARTITION BY %s" % partitionby
         # pattern for matching the null category column for a categorical variable
         # (assumes default of __NULL_ from collate.Compare):
         self.null_cat_pattern = '__NULL_' if null_cat_pattern is None else null_cat_pattern

--- a/collate/imputations.py
+++ b/collate/imputations.py
@@ -7,6 +7,8 @@ class BaseImputation(object):
         self.coltype = coltype
         self.catcol = coltype in ['categorical', 'array_categorical']
         self.partitionby = "" if partitionby is None else "PARTION BY %s" % partitionby
+        # pattern for matching the null category column for a categorical variable
+        # (assumes default of __NULL_ from collate.Compare):
         self.null_cat_pattern = '__NULL_' if null_cat_pattern is None else null_cat_pattern
     def _base_sql(self):
         return """COALESCE("{col}", {{imp}}) AS "{col}" """.format(col=self.column)        

--- a/collate/spacetime.py
+++ b/collate/spacetime.py
@@ -227,7 +227,7 @@ class SpacetimeAggregation(Aggregation):
                             "date '%s' - '%s' is before input_min_date ('%s')" %
                             (date, interval, self.input_min_date))
 
-    def find_nulls(self):
+    def find_nulls(self, imputed=False):
         """
         Generate query to count number of nulls in each column in the aggregation table
         
@@ -244,8 +244,11 @@ class SpacetimeAggregation(Aggregation):
             ])
 
         return query_template.format(
-                cols=cols_sql, state_tbl=self._state_table_sub(), aggs_tbl=self.get_table_name(),
-                group=self.state_group, date_col=self.output_date_column
+                cols=cols_sql, 
+                state_tbl=self._state_table_sub(), 
+                aggs_tbl=self.get_table_name(imputed=imputed),
+                group=self.state_group, 
+                date_col=self.output_date_column
             )
 
     def get_impute_create(self, impute_cols, nonimpute_cols):

--- a/collate/spacetime.py
+++ b/collate/spacetime.py
@@ -331,6 +331,15 @@ class SpacetimeAggregation(Aggregation):
                 imp = 1 if '_NULL' in column else 0
             )
 
+        # most frequent value of a binarized variable (not allowing for categoricals
+        # since this will NOT give the most frequent category -- need to do more
+        # work to figure out that logic)
+        elif impute_rule['type'] == 'binary_mode' and not catcol:
+            return sql.format(
+                imp="CASE WHEN AVG(%s) OVER (PARTITION BY %s) > 0.5 THEN 1 ELSE 0 END, 0" %\
+                 (column, self.output_date_column)
+            )
+
         # can specify an "error" imputation type that will simply raise an exception
         # if any null values have been found in the column
         elif impute_rule['type'] == 'error':

--- a/collate/spacetime.py
+++ b/collate/spacetime.py
@@ -229,7 +229,7 @@ class SpacetimeAggregation(Aggregation):
                 group=self.state_group, date_col=self.output_date_column
             )
 
-    def get_impute_create(self, impute_cols=[], nonimpute_cols=[]):
+    def get_impute_create(self, impute_cols, nonimpute_cols):
         """
         Generates the CREATE TABLE query for the aggregation table with imputation.
 

--- a/collate/spacetime.py
+++ b/collate/spacetime.py
@@ -236,7 +236,6 @@ class SpacetimeAggregation(Aggregation):
                     (date, self.state_table))
             r.close()
 
-
     def find_nulls(self, imputed=False):
         """
         Generate query to count number of nulls in each column in the aggregation table
@@ -273,7 +272,10 @@ class SpacetimeAggregation(Aggregation):
         """
 
         # key columns and date column
-        query = "SELECT %s, %s" % (', '.join(map(str, self.groups.values())), self.output_date_column)
+        query = "SELECT %s, %s" % (
+            ', '.join(map(str, self.groups.values())),
+            self.output_date_column
+            )
 
         # columns with imputation filling as needed
         query += self._get_impute_select(

--- a/collate/spacetime.py
+++ b/collate/spacetime.py
@@ -7,7 +7,7 @@ from .collate import Aggregation
 
 
 class SpacetimeAggregation(Aggregation):
-    def __init__(self, aggregates, groups, intervals, from_obj, dates, 
+    def __init__(self, aggregates, groups, intervals, from_obj, dates,
                  state_table, state_group=None,
                  prefix=None, suffix=None, schema=None, date_column=None,
                  output_date_column=None, input_min_date=None):
@@ -54,17 +54,17 @@ class SpacetimeAggregation(Aggregation):
         """
         datestr = ', '.join(["'%s'::date" % dt for dt in self.dates])
         mindtstr = " AND %s >= '%s'::date" %\
-                (self.output_date_column, self.input_min_date)\
-                if self.input_min_date is not None else ""
+            (self.output_date_column, self.input_min_date)\
+            if self.input_min_date is not None else ""
         return """(
-        SELECT * 
-        FROM {st} 
+        SELECT *
+        FROM {st}
         WHERE {datecol} IN ({datestr})
         {mindtstr})""".format(
-            st = self.state_table,
-            datecol = self.output_date_column,
-            datestr = datestr,
-            mindtstr = mindtstr
+            st=self.state_table,
+            datecol=self.output_date_column,
+            datestr=datestr,
+            mindtstr=mindtstr
         )
 
     def _get_aggregates_sql(self, interval, date, group):
@@ -230,12 +230,12 @@ class SpacetimeAggregation(Aggregation):
     def find_nulls(self, imputed=False):
         """
         Generate query to count number of nulls in each column in the aggregation table
-        
+
         Returns: a SQL SELECT statement
         """
         query_template = """
-            SELECT {cols} 
-            FROM {state_tbl} t1 
+            SELECT {cols}
+            FROM {state_tbl} t1
             LEFT JOIN {aggs_tbl} t2 USING({group}, {date_col})
             """
         cols_sql = ',\n'.join([
@@ -244,10 +244,10 @@ class SpacetimeAggregation(Aggregation):
             ])
 
         return query_template.format(
-                cols=cols_sql, 
-                state_tbl=self._state_table_sub(), 
+                cols=cols_sql,
+                state_tbl=self._state_table_sub(),
                 aggs_tbl=self.get_table_name(imputed=imputed),
-                group=self.state_group, 
+                group=self.state_group,
                 date_col=self.output_date_column
             )
 
@@ -267,8 +267,8 @@ class SpacetimeAggregation(Aggregation):
 
         # columns with imputation filling as needed
         query += self._get_impute_select(
-            impute_cols, 
-            nonimpute_cols, 
+            impute_cols,
+            nonimpute_cols,
             partitionby=self.output_date_column
         )
 
@@ -276,7 +276,7 @@ class SpacetimeAggregation(Aggregation):
         query += "\nFROM %s t1" % self._state_table_sub()
         query += "\nLEFT JOIN %s t2 USING(%s, %s)" % (
             self.get_table_name(),
-            self.state_group, 
+            self.state_group,
             self.output_date_column
             )
 

--- a/collate/spacetime.py
+++ b/collate/spacetime.py
@@ -260,7 +260,7 @@ class SpacetimeAggregation(Aggregation):
         # imputation starts from the state table and left joins into the aggregation table
         query += "\nFROM %s t1" % self.state_table
         query += "\nLEFT JOIN %s t2 USING(%s, %s)" % (
-            self.get_table_name()
+            self.get_table_name(),
             self.state_group, 
             self.output_date_column
             )

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -15,3 +15,4 @@ csvkit==1.0.2
 codecov==2.0.9
 pytest-cov==2.5.1
 testing.postgresql==1.3.0
+pandas

--- a/tests/initialize_db.py
+++ b/tests/initialize_db.py
@@ -14,7 +14,7 @@ system("""csvsql --no-constraints --table food_inspections < food_inspections_su
 system("""psql -c "\copy food_inspections FROM 'food_inspections_subset.csv' WITH CSV HEADER;" """)
 system("""psql -c "CREATE INDEX ON food_inspections(license_no, inspection_date)" """)
 
-# create a state table
+# create a state table for license/date
 sql = """CREATE TABLE inspection_states AS (
 SELECT license_no, inspection_date
 FROM (SELECT DISTINCT license_no FROM food_inspections) a
@@ -22,3 +22,10 @@ CROSS JOIN (SELECT DISTINCT inspection_date FROM food_inspections) b
 )""".replace('\n', ' ')
 system("""psql -c "%s" """ % sql)
 system("""psql -c "CREATE INDEX ON inspection_states(license_no, inspection_date)" """)
+
+# create a state table for licenseo only
+sql = """CREATE TABLE all_licenses AS (
+SELECT DISTINCT license_no FROM food_inspections
+)""".replace('\n', ' ')
+system("""psql -c "%s" """ % sql)
+system("""psql -c "CREATE INDEX ON all_licenses(license_no)" """)

--- a/tests/initialize_db.py
+++ b/tests/initialize_db.py
@@ -12,3 +12,13 @@ with open("config/database.yml") as f:
 system("""psql -c "DROP TABLE IF EXISTS food_inspections;" """)
 system("""csvsql --no-constraints --table food_inspections < food_inspections_subset.csv | psql """)
 system("""psql -c "\copy food_inspections FROM 'food_inspections_subset.csv' WITH CSV HEADER;" """)
+system("""psql -c "CREATE INDEX ON food_inspections(license_no, inspection_date)" """)
+
+# create a state table
+sql = """CREATE TABLE inspection_states AS (
+SELECT license_no, inspection_date
+FROM (SELECT DISTINCT license_no FROM food_inspections) a
+CROSS JOIN (SELECT DISTINCT inspection_date FROM food_inspections) b
+)""".replace('\n', ' ')
+system("""psql -c "%s" """ % sql)
+system("""psql -c "CREATE INDEX ON inspection_states(license_no, inspection_date)" """)

--- a/tests/initialize_db.py
+++ b/tests/initialize_db.py
@@ -15,15 +15,22 @@ system("""psql -c "\copy food_inspections FROM 'food_inspections_subset.csv' WIT
 system("""psql -c "CREATE INDEX ON food_inspections(license_no, inspection_date)" """)
 
 # create a state table for license/date
+system("""psql -c "DROP TABLE IF EXISTS inspection_states;" """)
 sql = """CREATE TABLE inspection_states AS (
-SELECT license_no, inspection_date
+SELECT license_no, date
 FROM (SELECT DISTINCT license_no FROM food_inspections) a
-CROSS JOIN (SELECT DISTINCT inspection_date FROM food_inspections) b
+CROSS JOIN (SELECT DISTINCT inspection_date as date FROM food_inspections) b
 )""".replace('\n', ' ')
 system("""psql -c "%s" """ % sql)
-system("""psql -c "CREATE INDEX ON inspection_states(license_no, inspection_date)" """)
+system("""psql -c "CREATE INDEX ON inspection_states(license_no, date)" """)
+
+# create an alternate state table with a different date column
+system("""psql -c "DROP TABLE IF EXISTS inspection_states_diff_colname;" """)
+system("""psql -c "CREATE TABLE inspection_states_diff_colname AS select license_no, date as aggregation_date from inspection_states" """)
+system("""psql -c "CREATE INDEX ON inspection_states_diff_colname(license_no, aggregation_date)" """)
 
 # create a state table for licenseo only
+system("""psql -c "DROP TABLE IF EXISTS all_licenses;" """)
 sql = """CREATE TABLE all_licenses AS (
 SELECT DISTINCT license_no FROM food_inspections
 )""".replace('\n', ' ')

--- a/tests/test_collate.py
+++ b/tests/test_collate.py
@@ -12,67 +12,101 @@ import pytest
 from collate import collate
 
 def test_aggregate():
-    agg = collate.Aggregate("*", "count")
+    agg = collate.Aggregate("*", "count", {})
     assert str(list(agg.get_columns())[0]) == "count(*)"
 
 def test_aggregate_when():
-    agg = collate.Aggregate("1", "count")
+    agg = collate.Aggregate("1", "count", {})
     assert str(list(agg.get_columns(when="date < '2012-01-01'"))[0]) == (
             "count(1) FILTER (WHERE date < '2012-01-01')")
 
 def test_ordered_aggregate():
-    agg = collate.Aggregate("", "mode", "x")
+    agg = collate.Aggregate("", "mode", {}, "x")
     assert str(list(agg.get_columns())[0]) == "mode() WITHIN GROUP (ORDER BY x)"
     assert list(agg.get_columns())[0].name == "x_mode"
 
 def test_ordered_aggregate_when():
-    agg = collate.Aggregate("", "mode", "x")
+    agg = collate.Aggregate("", "mode", {}, "x")
     assert str(list(agg.get_columns(when="date < '2012-01-01'"))[0]) == (
             "mode() WITHIN GROUP (ORDER BY x) FILTER (WHERE date < '2012-01-01')")
 
 def test_aggregate_tuple_quantity():
-    agg = collate.Aggregate(("x","y"), "corr")
+    agg = collate.Aggregate(("x","y"), "corr", {})
     assert str(list(agg.get_columns())[0]) == "corr(x, y)"
 
 def test_aggregate_tuple_quantity_when():
-    agg = collate.Aggregate(("x","y"), "corr")
+    agg = collate.Aggregate(("x","y"), "corr", {})
     assert str(list(agg.get_columns(when="date < '2012-01-01'"))[0]) == (
             "corr(x, y) FILTER (WHERE date < '2012-01-01')")
 
+def test_aggregate_imputation_lookup():
+    agg = collate.Aggregate("a", ["avg", "sum"], {
+        "coltype": "aggregate",
+        "avg": {"type": "mean"}, 
+        "sum": {"type": "constant", "value": 3},
+        "max": {"type": "zero"}
+        })
+    assert agg.column_imputation_lookup()['a_avg']['type'] == 'mean'
+    assert agg.column_imputation_lookup()['a_avg']['coltype'] == 'aggregate'
+    assert agg.column_imputation_lookup()['a_sum']['type'] == 'constant'
+    assert agg.column_imputation_lookup()['a_sum']['value'] == 3
+    assert agg.column_imputation_lookup()['a_sum']['coltype'] == 'aggregate'
+
+def test_aggregate_imputation_lookup_all():
+    agg = collate.Aggregate("a", ["avg", "sum"], {
+        "coltype": "aggregate",
+        "all": {"type": "zero"}, 
+        "sum": {"type": "constant", "value": 3},
+        "max": {"type": "mean"}
+        })
+    assert agg.column_imputation_lookup()['a_avg']['type'] == 'zero'
+    assert agg.column_imputation_lookup()['a_avg']['coltype'] == 'aggregate'
+    assert agg.column_imputation_lookup()['a_sum']['type'] == 'constant'
+    assert agg.column_imputation_lookup()['a_sum']['value'] == 3
+    assert agg.column_imputation_lookup()['a_sum']['coltype'] == 'aggregate'
+
 def test_aggregate_arithmetic():
-    n = collate.Aggregate("x", "sum")
-    d = collate.Aggregate("1", "count")
-    m = collate.Aggregate("y", "avg")
+    n = collate.Aggregate("x", "sum", {})
+    d = collate.Aggregate("1", "count", {})
+    m = collate.Aggregate("y", "avg", {})
 
     e = list((n/d + m).get_columns(prefix="prefix_"))[0]
     assert str(e) == "((sum(x)*1.0 / count(1)) + avg(y))"
     assert e.name == "prefix_x_sum/1_count+y_avg"
 
 def test_aggregate_format_kwargs():
-    agg = collate.Aggregate("'{collate_date}' - date", "min")
+    agg = collate.Aggregate("'{collate_date}' - date", "min", {})
     assert str(list(agg.get_columns(format_kwargs={"collate_date":"2012-01-01"}))[0]) == (
             "min('2012-01-01' - date)")
 
 def test_aggregation_table_name_no_schema():
     # no schema
-    assert collate.Aggregation([], from_obj='source', groups=[])\
+    assert collate.Aggregation([], from_obj='source', groups=[], state_table='tbl')\
             .get_table_name() == '"source_aggregation"'
+    assert collate.Aggregation([], from_obj='source', groups=[], state_table='tbl')\
+            .get_table_name(imputed=True) == '"source_aggregation_imputed"'
 
     # prefix
     assert collate.Aggregation([], from_obj='source', prefix="mysource",
-            groups=[])\
+            groups=[], state_table='tbl')\
             .get_table_name() == '"mysource_aggregation"'
+    assert collate.Aggregation([], from_obj='source', prefix="mysource",
+            groups=[], state_table='tbl')\
+            .get_table_name(imputed=True) == '"mysource_aggregation_imputed"'
 
     # schema
     assert collate.Aggregation([], from_obj='source', schema='schema',
-            groups=[])\
+            groups=[], state_table='tbl')\
             .get_table_name() == '"schema"."source_aggregation"'
+    assert collate.Aggregation([], from_obj='source', schema='schema',
+            groups=[], state_table='tbl')\
+            .get_table_name(imputed=True) == '"schema"."source_aggregation_imputed"'
 
 def test_distinct():
-    assert str(list(collate.Aggregate("distinct x", "count").get_columns())[0]) == "count(distinct x)"
+    assert str(list(collate.Aggregate("distinct x", "count", {}).get_columns())[0]) == "count(distinct x)"
 
-    assert str(list(collate.Aggregate("distinct x", "count").get_columns(when="date < '2012-01-01'"))[0]) == "count(distinct x) FILTER (WHERE date < '2012-01-01')"
+    assert str(list(collate.Aggregate("distinct x", "count", {}).get_columns(when="date < '2012-01-01'"))[0]) == "count(distinct x) FILTER (WHERE date < '2012-01-01')"
 
-    assert str(list(collate.Aggregate("distinct(x)", "count").get_columns(when="date < '2012-01-01'"))[0]) == "count(distinct (x)) FILTER (WHERE date < '2012-01-01')"
+    assert str(list(collate.Aggregate("distinct(x)", "count", {}).get_columns(when="date < '2012-01-01'"))[0]) == "count(distinct (x)) FILTER (WHERE date < '2012-01-01')"
 
-    assert str(list(collate.Aggregate("distinct(x,y)", "count").get_columns(when="date < '2012-01-01'"))[0]) == "count(distinct (x,y)) FILTER (WHERE date < '2012-01-01')"
+    assert str(list(collate.Aggregate("distinct(x,y)", "count", {}).get_columns(when="date < '2012-01-01'"))[0]) == "count(distinct (x,y)) FILTER (WHERE date < '2012-01-01')"

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -7,7 +7,7 @@ def assert_contains(haystack, needle):
     assert False
 
 def test_compare_lists():
-    d = collate.Compare('col','=',['a','b','c'],[],include_null=True).quantities
+    d = collate.Compare('col','=',['a','b','c'],[],{},include_null=True).quantities
     assert len(d) == 4
     assert len(set(d.values())) == len(d)
     assert len(set(d.keys())) == len(d)
@@ -16,7 +16,7 @@ def test_compare_lists():
     assert_contains(d.values(), "col = 'c'")
     assert_contains(map(lambda x: x[0].lower(), d.values()), "col is null")
 
-    d = collate.Compare('col','>',[1,2,3],[]).quantities
+    d = collate.Compare('col','>',[1,2,3],[],{}).quantities
     assert len(d) == 3
     assert len(set(d.values())) == len(d)
     assert len(set(d.keys())) == len(d)
@@ -24,7 +24,7 @@ def test_compare_lists():
     assert_contains(d.values(), "col > 2")
     assert_contains(d.values(), "col > 3")
 
-    d = collate.Compare('col','=',['a','b','c'], [], include_null=False).quantities
+    d = collate.Compare('col','=',['a','b','c'], [], {}, include_null=False).quantities
     assert len(d) == 3
     assert len(set(d.values())) == len(d)
     assert len(set(d.keys())) == len(d)
@@ -36,7 +36,7 @@ def test_compare_lists():
         ['really long string value that is similar to others',
          'really long string value that is like others',
          'really long string value that is quite alike to others',
-         'really long string value that is also like everything else'], [], maxlen=32).quantities
+         'really long string value that is also like everything else'], [], {}, maxlen=32).quantities
     assert len(d) == 4
     assert len(set(d.values())) == len(d)
     assert len(set(d.keys())) == len(d)
@@ -53,6 +53,7 @@ def test_compare_override_quoting():
         '@>',
         {'one': "array['one'::varchar]", 'two': "array['two'::varchar]"},
         [],
+        {},
         quote_choices=False
     ).quantities
     assert len(d) == 2
@@ -61,7 +62,7 @@ def test_compare_override_quoting():
 
 
 def test_compare_dicts():
-    d = collate.Compare('col','=',{'vala': 'a','valb': 'b','valc': 'c'}, [], include_null=True).quantities
+    d = collate.Compare('col','=',{'vala': 'a','valb': 'b','valc': 'c'}, [], {}, include_null=True).quantities
     assert len(d) == 4
     assert len(set(d.values())) == len(d)
     assert len(set(d.keys())) == len(d)
@@ -74,7 +75,7 @@ def test_compare_dicts():
     assert_contains(map(str.lower, d.keys()), 'null')
     assert_contains(map(lambda x: x[0].lower(), d.values()), "col is null")
 
-    d = collate.Compare('col','<',{'val1': 1,'val2': 2,'val3': 3}, [], include_null='missing').quantities
+    d = collate.Compare('col','<',{'val1': 1,'val2': 2,'val3': 3}, [], {}, include_null='missing').quantities
     assert len(d) == 4
     assert len(set(d.values())) == len(d)
     assert len(set(d.keys())) == len(d)
@@ -91,7 +92,7 @@ def test_compare_dicts():
         {'really long string key that is similar to others': 'really long string value that is similar to others',
          'really long string key that is like others': 'really long string value that is like others',
          'different key': 'really long string value that is quite alike to others',
-         'ni': 'really long string value that is also like everything else'}, [], maxlen=32).quantities
+         'ni': 'really long string value that is also like everything else'}, [], {}, maxlen=32).quantities
     assert len(d) == 4
     assert len(set(d.values())) == len(d)
     assert len(set(d.keys())) == len(d)
@@ -103,15 +104,15 @@ def test_compare_dicts():
     assert_contains(d.values(), "long_column_name = 'really long string value that is also like everything else'")
 
 def test_categorical_same_as_compare():
-    d1 = collate.Categorical('col',{'vala': 'a','valb': 'b','valc': 'c'}, []).quantities
-    d2 = collate.Compare('col','=',{'vala': 'a','valb': 'b','valc': 'c'}, []).quantities
+    d1 = collate.Categorical('col',{'vala': 'a','valb': 'b','valc': 'c'}, [], {}).quantities
+    d2 = collate.Compare('col','=',{'vala': 'a','valb': 'b','valc': 'c'}, [], {}).quantities
     assert sorted(d1.values()) == sorted(d2.values())
-    d3 = collate.Categorical('col',{'vala': 'a','valb': 'b','valc': 'c'}, [], op_in_name=True).quantities
+    d3 = collate.Categorical('col',{'vala': 'a','valb': 'b','valc': 'c'}, [], {}, op_in_name=True).quantities
     assert d2 == d3
 
 def test_categorical_nones():
-    d1 = collate.Categorical('col',{'vala': 'a','valb': 'b','valc': 'c','_NULL': None}, []).quantities
-    d2 = collate.Compare('col','=',{'vala': 'a','valb': 'b','valc': 'c'}, [], op_in_name=False, include_null=True).quantities
+    d1 = collate.Categorical('col',{'vala': 'a','valb': 'b','valc': 'c','_NULL': None}, [], {}).quantities
+    d2 = collate.Compare('col','=',{'vala': 'a','valb': 'b','valc': 'c'}, [], {}, op_in_name=False, include_null=True).quantities
     assert d1 == d2
-    d3 = collate.Categorical('col',['a','b','c',None],[]).quantities
+    d3 = collate.Categorical('col',['a','b','c',None],[], {}).quantities
     assert sorted(d1.values()) == sorted(d2.values())

--- a/tests/test_imputation_output.py
+++ b/tests/test_imputation_output.py
@@ -96,7 +96,7 @@ aggs_table_noimp = [
 def test_available_imputations_coverage():
     assert set(available_imputations.keys()) == set(list(imputation_values.keys()) + ['error'])
 
-def test_imputation_base(feat_list, exp_imp_cols, feat_table):
+def _base_imputation_test(feat_list, exp_imp_cols, feat_table):
     with testing.postgresql.Postgresql() as psql:
         engine = sqlalchemy.create_engine(psql.url())
 
@@ -201,14 +201,14 @@ def test_imputation_base(feat_list, exp_imp_cols, feat_table):
                         assert 'prefix_entity_id_1y_%s_max_imp' % feat not in df.columns.values
 
 def test_imputation_output():
-    return test_imputation_base(
+    return _base_imputation_test(
         feat_list=['f1', 'f2', 'f3', 'f4'], 
         exp_imp_cols = ['f1', 'f2', 'f3', 'f4'],
         feat_table=aggs_table
         )
 
 def test_non_imputation_output():
-    return test_imputation_base(
+    return _base_imputation_test(
         feat_list=['f5', 'f6'], 
         exp_imp_cols = ['f5'],
         feat_table=aggs_table_noimp

--- a/tests/test_imputation_output.py
+++ b/tests/test_imputation_output.py
@@ -1,0 +1,207 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""
+test_imputation_output
+----------------------------------
+
+Unit tests for imputation output.
+"""
+
+
+import pytest
+from collate.collate import Aggregate, available_imputations
+from collate.spacetime import SpacetimeAggregation
+
+import sqlalchemy
+import testing.postgresql
+
+# some imputations require arguments, so specify default values here
+# everything in collate.collate.available_imputations needs a record here!
+imputation_values = {
+    'mean': {
+        'aggregate': {'avail': True, 'kwargs': {}},
+        'categorical': {'avail': True, 'kwargs': {}}
+    },
+    'constant': {
+        'aggregate': {'avail': True, 'kwargs': {'value': 7}},
+        'categorical': {'avail': True, 'kwargs': {'value': 'foo'}}
+    },
+    'zero': {
+        'aggregate': {'avail': True, 'kwargs': {}},
+        'categorical': {'avail': True, 'kwargs': {}}
+    },
+    'null_category': {
+        'aggregate': {'avail': False},
+        'categorical': {'avail': True, 'kwargs': {}}
+    },
+    'binary_mode': {
+        'aggregate': {'avail': True, 'kwargs': {}},
+        'categorical': {'avail': False}
+    },
+}
+
+states_table = [
+    # entity_id, as_of_date
+    [1, '2016-01-01'],
+    [2, '2016-01-01'],
+    [3, '2016-01-01'],
+    [4, '2016-01-01'],
+    [1, '2016-02-03'],
+    [2, '2016-02-03'],
+    [3, '2016-02-03'],
+    [4, '2016-02-03'],
+    [1, '2016-03-14'],
+    [2, '2016-03-14'],
+    [3, '2016-03-14']
+    [4, '2016-03-14']
+]
+
+aggs_table = [
+    # entity_id, as_of_date, f1, f2, f3, f4
+    [1, '2016-01-01', None, 1, 3, 0],
+    [2, '2016-01-01', None, 5, None, 0],
+    [3, '2016-01-01', None, 7, 3, 0],
+    [4, '2016-01-01', None, 4, 3, 0],
+    [1, '2016-02-03', None, None, 3, 0],
+    [2, '2016-02-03', None, None, 5, 8],
+    [3, '2016-02-03', None, None, None, 2],
+    [4, '2016-02-03', None, None, 4, 6],
+    [1, '2016-03-14', None, 1, 3, 2],
+    [4, '2016-03-14', None, 3, 9, 1]
+]
+
+aggs_table_noimp = [
+    # entity_id, as_of_date, f5, f6
+    [1, '2016-01-01', 3, 0],
+    [2, '2016-01-01', None, 0],
+    [3, '2016-01-01', 3, 0],
+    [4, '2016-01-01', 3, 0],
+    [1, '2016-02-03', 3, 0],
+    [2, '2016-02-03', 5, 8],
+    [3, '2016-02-03', None, 2],
+    [4, '2016-02-03', 4, 6],
+    [1, '2016-03-14', 3, 2],
+    [2, '2016-03-14', None, 2],
+    [3, '2016-03-14', None, 1]
+    [4, '2016-03-14', 9, 1]
+]
+
+def test_available_imputations_coverage():
+    assert set(available_imputations.keys()) == set(imputation_values.keys() + ['error'])
+
+def test_imputation_base(feat_list, exp_imp_cols, feat_table):
+    with testing.postgresql.Postgresql() as psql:
+        engine = sqlalchemy.create_engine(psql.url())
+
+        engine.execute(
+            'create table states (entity_id int, as_of_date date)'
+        )
+        for state in states_table:
+            engine.execute(
+                'insert into states values (%s, %s)',
+                state
+            )
+
+        feat_sql = [', prefix_entiy_id_1y_%s_max int' % f for f in feat_list]
+        engine.execute(
+            '''create table prefix_aggregation (
+                entity_id int
+                , as_of_date date
+                %s
+                )''' % feat_sql
+        )
+        ins_sql = 'insert into prefix_aggregation values (%s, %s'+\
+            (', %s' * len(feat_list))+')'
+        for rec in aggs_table:
+            engine.execute(
+                ins_sql,
+                rec
+            )
+
+        for imp in available_imputations.keys():
+            # skip error imputation
+            if imp == 'error':
+                continue
+
+            for coltype in ['aggregate', 'categorical']:
+                # only consider 
+                if not imputation_values[imp][coltype]['avail']:
+                    continue
+
+                impargs = imputation_values[imp][coltype]
+                aggs = [
+                    Aggregate(
+                        feat, ['max'], {'coltype': coltype, 'all': dict(type=imp, **impargs)}
+                    ) for feat in feat_list
+                ]
+                st = SpacetimeAggregation(
+                        aggregates = aggs,
+                        from_obj = 'prefix_events',
+                        groups = ['entity_id'],
+                        intervals = ['all'],
+                        dates = ['2016-01-01', '2016-02-03', '2016-03-14'],
+                        state_table = 'states',
+                        state_group = 'entity_id',
+                        date_column = 'as_of_date',
+                        input_min_date = '2000-01-01'
+                    )
+
+                conn = engine.connect()
+
+                trans = conn.begin()
+
+                # excute query to find columns with null values and create lists of columns
+                # that do and do not need imputation when creating the imputation table
+                res = conn.execute(st.find_nulls())
+                null_counts = list(zip(res.keys(), res.fetchone()))
+                impute_cols = [col for col, val in null_counts if val > 0]
+                nonimpute_cols = [col for col, val in null_counts if val == 0]
+
+                # sql to drop and create the imputation table
+                drop_imp = st.get_drop(imputed=True)
+                create_imp = st.get_impute_create(
+                            impute_cols=impute_cols, 
+                            nonimpute_cols=nonimpute_cols
+                            )
+
+                # create the imputation table
+                conn.execute(drop_imp)
+                conn.execute(create_imp)
+
+                trans.commit()
+
+                # check the results
+                df = pd.from_sql('SELECT * FROM prefix_aggregation_imputed')
+
+                # we should have a record for every entity/date combo
+                assert df.shape[0] == len(states_table)
+
+                for feat in feat_list:
+                    # all of the input columns should be in the result and be null-free
+                    assert 'prefix_entiy_id_1y_%s_max' % feat in df.columns.values
+                    assert df['prefix_entiy_id_1y_%s_max' % feat].isnull().sum() == 0
+
+                    # for non-categoricals, should add an "imputed" column and be non-null
+                    if feat in exp_imp_cols AND coltype != 'categorical':
+                        assert 'prefix_entiy_id_1y_%s_max_imp' % feat in df.columns.values
+                        assert df['prefix_entiy_id_1y_%s_max_imp' % feat].isnull().sum() == 0
+
+                    # should not generate an imputed column when not needed
+                    if feat not in exp_imp_cols:
+                        assert 'prefix_entiy_id_1y_%s_max_imp' % feat not in df.columns.values
+
+def test_imputation_output():
+    return test_imputation_base(
+        feat_list=['f1', 'f2', 'f3', 'f4'], 
+        exp_imp_cols = ['f1', 'f2', 'f3', 'f4']
+        feat_table=aggs_table
+        )
+
+def test_non_imputation_output():
+    return test_imputation_base(
+        feat_list=['f5', 'f6'], 
+        exp_imp_cols = ['f5'],
+        feat_table=aggs_table_noimp
+        )
+

--- a/tests/test_imputation_output.py
+++ b/tests/test_imputation_output.py
@@ -91,11 +91,15 @@ aggs_table_noimp = [
     [4, '2016-03-14', 9, 1]
 ]
 
+# DELETE ME
+pgpath = '/usr/lib/postgresql/9.6/bin/'
+# DELETE ME
+
 def test_available_imputations_coverage():
     assert set(available_imputations.keys()) == set(list(imputation_values.keys()) + ['error'])
 
 def test_imputation_base(feat_list, exp_imp_cols, feat_table):
-    with testing.postgresql.Postgresql() as psql:
+    with testing.postgresql.Postgresql(initdb=pgpath+'initdb', postgres=pgpath+'postgres') as psql:
         engine = sqlalchemy.create_engine(psql.url())
 
         engine.execute(

--- a/tests/test_imputation_output.py
+++ b/tests/test_imputation_output.py
@@ -6,8 +6,12 @@ test_imputation_output
 ----------------------------------
 
 Unit tests for imputation output.
-"""
 
+For all available imputation methods, make sure they correctly handle a variety
+of cases, including completely null columns and columns entirely null for a given 
+date, generating the right number of records with no nulls in the output set and
+imputed flags as necessary.
+"""
 
 import pytest
 from collate.collate import Aggregate, available_imputations
@@ -183,6 +187,7 @@ def test_imputation_base(feat_list, exp_imp_cols, feat_table):
                     assert df['prefix_entiy_id_1y_%s_max' % feat].isnull().sum() == 0
 
                     # for non-categoricals, should add an "imputed" column and be non-null
+                    # (categoricals are expected to be handled through the null category)
                     if feat in exp_imp_cols AND coltype != 'categorical':
                         assert 'prefix_entiy_id_1y_%s_max_imp' % feat in df.columns.values
                         assert df['prefix_entiy_id_1y_%s_max_imp' % feat].isnull().sum() == 0

--- a/tests/test_imputation_output.py
+++ b/tests/test_imputation_output.py
@@ -36,6 +36,10 @@ imputation_values = {
         'aggregate': {'avail': True, 'kwargs': {}},
         'categorical': {'avail': True, 'kwargs': {}}
     },
+    'zero_noflag': {
+        'aggregate': {'avail': True, 'kwargs': {}},
+        'categorical': {'avail': True, 'kwargs': {}}
+    },
     'null_category': {
         'aggregate': {'avail': False},
         'categorical': {'avail': True, 'kwargs': {}}
@@ -192,12 +196,12 @@ def _base_imputation_test(feat_list, exp_imp_cols, feat_table):
 
                     # for non-categoricals, should add an "imputed" column and be non-null
                     # (categoricals are expected to be handled through the null category)
-                    if feat in exp_imp_cols and coltype != 'categorical':
+                    # zero_noflag imputation should not generate a flag either
+                    if feat in exp_imp_cols and coltype != 'categorical' and imp != 'zero_noflag':
                         assert 'prefix_entity_id_1y_%s_max_imp' % feat in df.columns.values
                         assert df['prefix_entity_id_1y_%s_max_imp' % feat].isnull().sum() == 0
-
-                    # should not generate an imputed column when not needed
-                    if feat not in exp_imp_cols:
+                    else:
+                        # should not generate an imputed column when not needed
                         assert 'prefix_entity_id_1y_%s_max_imp' % feat not in df.columns.values
 
 def test_imputation_output():

--- a/tests/test_imputation_output.py
+++ b/tests/test_imputation_output.py
@@ -57,7 +57,7 @@ states_table = [
     [4, '2016-02-03'],
     [1, '2016-03-14'],
     [2, '2016-03-14'],
-    [3, '2016-03-14']
+    [3, '2016-03-14'],
     [4, '2016-03-14']
 ]
 
@@ -87,12 +87,12 @@ aggs_table_noimp = [
     [4, '2016-02-03', 4, 6],
     [1, '2016-03-14', 3, 2],
     [2, '2016-03-14', None, 2],
-    [3, '2016-03-14', None, 1]
+    [3, '2016-03-14', None, 1],
     [4, '2016-03-14', 9, 1]
 ]
 
 def test_available_imputations_coverage():
-    assert set(available_imputations.keys()) == set(imputation_values.keys() + ['error'])
+    assert set(available_imputations.keys()) == set(list(imputation_values.keys()) + ['error'])
 
 def test_imputation_base(feat_list, exp_imp_cols, feat_table):
     with testing.postgresql.Postgresql() as psql:
@@ -188,7 +188,7 @@ def test_imputation_base(feat_list, exp_imp_cols, feat_table):
 
                     # for non-categoricals, should add an "imputed" column and be non-null
                     # (categoricals are expected to be handled through the null category)
-                    if feat in exp_imp_cols AND coltype != 'categorical':
+                    if feat in exp_imp_cols and coltype != 'categorical':
                         assert 'prefix_entiy_id_1y_%s_max_imp' % feat in df.columns.values
                         assert df['prefix_entiy_id_1y_%s_max_imp' % feat].isnull().sum() == 0
 
@@ -199,7 +199,7 @@ def test_imputation_base(feat_list, exp_imp_cols, feat_table):
 def test_imputation_output():
     return test_imputation_base(
         feat_list=['f1', 'f2', 'f3', 'f4'], 
-        exp_imp_cols = ['f1', 'f2', 'f3', 'f4']
+        exp_imp_cols = ['f1', 'f2', 'f3', 'f4'],
         feat_table=aggs_table
         )
 

--- a/tests/test_imputations.py
+++ b/tests/test_imputations.py
@@ -61,6 +61,21 @@ def test_impute_zero():
     imp = ImputeZero(column='a__NULL_mean', coltype='categorical')
     assert imp.to_sql() == 'COALESCE("a__NULL_mean", 1) AS "a__NULL_mean" '
 
+def test_impute_zero_noflag():
+    imp = ImputeZeroNoFlag(column='a', coltype='aggregate')
+    assert imp.to_sql() == 'COALESCE("a", 0) AS "a" '
+    assert imp.imputed_flag_sql() is None
+    assert imp.noflag
+
+    imp = ImputeZeroNoFlag(column='a_myval_max', coltype='categorical')
+    assert imp.to_sql() == 'COALESCE("a_myval_max", 0) AS "a_myval_max" '
+
+    imp = ImputeZeroNoFlag(column='a_otherval_max', coltype='categorical')
+    assert imp.to_sql() == 'COALESCE("a_otherval_max", 0) AS "a_otherval_max" '
+
+    imp = ImputeZeroNoFlag(column='a__NULL_mean', coltype='categorical')
+    assert imp.to_sql() == 'COALESCE("a__NULL_mean", 0) AS "a__NULL_mean" '
+
 def test_impute_null_cat():
     imp = ImputeNullCategory(column='a_myval_max', coltype='categorical')
     assert imp.to_sql() == 'COALESCE("a_myval_max", 0) AS "a_myval_max" '

--- a/tests/test_imputations.py
+++ b/tests/test_imputations.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""
+test_imputations
+----------------------------------
+
+Unit tests for `collate.imputations` module.
+"""
+
+import pytest
+from collate.imputations import *
+
+def test_impute_flag():
+    imp = BaseImputation(column='a', coltype='aggregate')
+    assert imp.imputed_flag_sql() == 'CASE WHEN "a" IS NULL THEN 1 ELSE 0 END AS "a_imp" '
+
+def test_impute_flag_categorical():
+    imp = BaseImputation(column='a', coltype='categorical')
+    assert imp.imputed_flag_sql() is None
+
+def test_mean_imputation():
+    imp = ImputeMean(column='a', coltype='aggregate')
+    assert imp.to_sql() == 'COALESCE("a", AVG("a") OVER (), 0) AS "a" '
+
+    imp = ImputeMean(column='a', coltype='aggregate', partitionby='date')
+    assert imp.to_sql() == 'COALESCE("a", AVG("a") OVER (PARTION BY date), 0) AS "a" '
+
+    imp = ImputeMean(column='a', coltype='categorical')
+    assert imp.to_sql() == 'COALESCE("a", AVG("a") OVER (), 0) AS "a" '
+
+    imp = ImputeMean(column='a', coltype='aggregate', partitionby='date')
+    assert imp.to_sql() == 'COALESCE("a", AVG("a") OVER (PARTION BY date), 0) AS "a" '
+
+    imp = ImputeMean(column='a__NULL_mean', coltype='categorical')
+    assert imp.to_sql() == 'COALESCE("a__NULL_mean", 1) AS "a__NULL_mean" '
+
+def test_constant_imputation():
+    imp = ImputeConstant(column='a', coltype='aggregate', value=3.14)
+    assert imp.to_sql() == 'COALESCE("a", 3.14) AS "a" '
+
+    imp = ImputeConstant(column='a_myval_max', coltype='categorical', value='myval')
+    assert imp.to_sql() == 'COALESCE("a_myval_max", 1) AS "a_myval_max" '
+
+    imp = ImputeConstant(column='a_otherval_max', coltype='categorical', value='myval')
+    assert imp.to_sql() == 'COALESCE("a_otherval_max", 0) AS "a_otherval_max" '
+
+    imp = ImputeConstant(column='a__NULL_mean', coltype='categorical', value='myval')
+    assert imp.to_sql() == 'COALESCE("a__NULL_mean", 1) AS "a__NULL_mean" '
+
+def test_impute_zero():
+    imp = ImputeZero(column='a', coltype='aggregate')
+    assert imp.to_sql() == 'COALESCE("a", 0) AS "a" '
+
+    imp = ImputeZero(column='a_myval_max', coltype='categorical')
+    assert imp.to_sql() == 'COALESCE("a_myval_max", 0) AS "a_myval_max" '
+
+    imp = ImputeZero(column='a_otherval_max', coltype='categorical')
+    assert imp.to_sql() == 'COALESCE("a_otherval_max", 0) AS "a_otherval_max" '
+
+    imp = ImputeZero(column='a__NULL_mean', coltype='categorical')
+    assert imp.to_sql() == 'COALESCE("a__NULL_mean", 1) AS "a__NULL_mean" '
+
+def test_impute_null_cat():
+    imp = ImputeNullCategory(column='a_myval_max', coltype='categorical')
+    assert imp.to_sql() == 'COALESCE("a_myval_max", 0) AS "a_myval_max" '
+
+    imp = ImputeNullCategory(column='a_otherval_max', coltype='categorical')
+    assert imp.to_sql() == 'COALESCE("a_otherval_max", 0) AS "a_otherval_max" '
+
+    imp = ImputeNullCategory(column='a__NULL_mean', coltype='categorical')
+    assert imp.to_sql() == 'COALESCE("a__NULL_mean", 1) AS "a__NULL_mean" '
+
+    try:
+        imp = ImputeNullCategory(column='a', coltype='aggregate')
+        imp.to_sql()
+        assert False
+    except ValueError:
+        assert True
+    else:
+        assert False
+
+def test_impute_binary_mode():
+    imp = ImputeBinaryMode(column='a', coltype='aggregate')
+    assert imp.to_sql() == 'COALESCE("a", CASE WHEN AVG("a") OVER () > 0.5 THEN 1 ELSE 0 END, 0) AS "a" '
+
+    imp = ImputeBinaryMode(column='a', coltype='aggregate', partitionby='date')
+    assert imp.to_sql() == 'COALESCE("a", CASE WHEN AVG("a") OVER (PARTION BY date) > 0.5 THEN 1 ELSE 0 END, 0) AS "a" '
+
+    try:
+        imp = ImputeBinaryMode(column='a', coltype='categorical')
+        imp.to_sql()
+        assert False
+    except ValueError:
+        assert True
+    else:
+        assert False
+
+def test_impute_error():
+    try:
+        imp = ImputeError(column='a', coltype='aggregate')
+        imp.to_sql()
+        assert False
+    except ValueError:
+        assert True
+    else:
+        assert False
+

--- a/tests/test_imputations.py
+++ b/tests/test_imputations.py
@@ -24,13 +24,13 @@ def test_mean_imputation():
     assert imp.to_sql() == 'COALESCE("a", AVG("a") OVER (), 0) AS "a" '
 
     imp = ImputeMean(column='a', coltype='aggregate', partitionby='date')
-    assert imp.to_sql() == 'COALESCE("a", AVG("a") OVER (PARTION BY date), 0) AS "a" '
+    assert imp.to_sql() == 'COALESCE("a", AVG("a") OVER (PARTITION BY date), 0) AS "a" '
 
     imp = ImputeMean(column='a', coltype='categorical')
     assert imp.to_sql() == 'COALESCE("a", AVG("a") OVER (), 0) AS "a" '
 
     imp = ImputeMean(column='a', coltype='aggregate', partitionby='date')
-    assert imp.to_sql() == 'COALESCE("a", AVG("a") OVER (PARTION BY date), 0) AS "a" '
+    assert imp.to_sql() == 'COALESCE("a", AVG("a") OVER (PARTITION BY date), 0) AS "a" '
 
     imp = ImputeMean(column='a__NULL_mean', coltype='categorical')
     assert imp.to_sql() == 'COALESCE("a__NULL_mean", 1) AS "a__NULL_mean" '
@@ -85,7 +85,7 @@ def test_impute_binary_mode():
     assert imp.to_sql() == 'COALESCE("a", CASE WHEN AVG("a") OVER () > 0.5 THEN 1 ELSE 0 END, 0) AS "a" '
 
     imp = ImputeBinaryMode(column='a', coltype='aggregate', partitionby='date')
-    assert imp.to_sql() == 'COALESCE("a", CASE WHEN AVG("a") OVER (PARTION BY date) > 0.5 THEN 1 ELSE 0 END, 0) AS "a" '
+    assert imp.to_sql() == 'COALESCE("a", CASE WHEN AVG("a") OVER (PARTITION BY date) > 0.5 THEN 1 ELSE 0 END, 0) AS "a" '
 
     try:
         imp = ImputeBinaryMode(column='a', coltype='categorical')

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -24,8 +24,13 @@ def test_engine():
     assert len(engine.execute("SELECT * FROM food_inspections").fetchall()) == 966
 
 def test_st_explicit_execute():
-    agg = Aggregate("results='Fail'",["count"])
-    mode = Aggregate("", "mode", order="zip")
+    impute_rules={
+        'coltype': 'aggregate', 
+        'count': {'type': 'mean'},
+        'mode': {'type': 'mean'}
+        }
+    agg = Aggregate("results='Fail'",["count"],impute_rules)
+    mode = Aggregate("", "mode", impute_rules, order="zip")
     st = SpacetimeAggregation([agg, agg+agg, mode],
         from_obj = ex.table('food_inspections'),
         groups = {'license':ex.column('license_no'), 
@@ -33,19 +38,28 @@ def test_st_explicit_execute():
         intervals = {'license' : ["1 year", "2 years", "all"],
                            'zip' : ["1 year"]},
         dates = ['2016-08-31', '2015-08-31'],
+        state_table = 'inspection_states',
+        state_group = 'license_no',
         date_column = 'inspection_date',
         prefix='food_inspections')
 
     st.execute(engine.connect())
 
 def test_st_lazy_execute():
-    agg = Aggregate("results='Fail'",["count"])
+    impute_rules={
+        'coltype': 'aggregate', 
+        'count': {'type': 'mean'},
+        'mode': {'type': 'mean'}
+        }
+    agg = Aggregate("results='Fail'",["count"],impute_rules)
     st = SpacetimeAggregation([agg],
         from_obj = 'food_inspections',
         groups = ['license_no', 'zip'],
         intervals = {'license_no':["1 year", "2 years", "all"],
                            'zip' : ["1 year"]},
         dates = ['2016-08-31', '2015-08-31'],
+        state_table = 'inspection_states',
+        state_group = 'license_no',
         date_column = '"inspection_date"')
 
     st.execute(engine.connect())
@@ -57,6 +71,8 @@ def test_st_execute_broadcast_intervals():
         groups = ['license_no', 'zip'],
         intervals = ["1 year", "2 years", "all"],
         dates = ['2016-08-31', '2015-08-31'],
+        state_table = 'inspection_states',
+        state_group = 'license_no',
         date_column = '"inspection_date"')
 
     st.execute(engine.connect())
@@ -77,6 +93,8 @@ def test_execute_schema_output_date_column():
         intervals = {'license_no':["1 year", "2 years", "all"],
                            'zip' : ["1 year"]},
         dates = ['2016-08-31', '2015-08-31'],
+        state_table = 'inspection_states',
+        state_group = 'license_no',
         schema = "agg",
         date_column = '"inspection_date"',
         output_date_column = "aggregation_date")

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -81,7 +81,9 @@ def test_execute():
     agg = Aggregate("results='Fail'",["count"])
     st = Aggregation([agg],
         from_obj = 'food_inspections',
-        groups = ['license_no', 'zip'])
+        groups = ['license_no', 'zip'],
+        state_table = 'all_licenses',
+        state_group = 'license_no')
 
     st.execute(engine.connect())
 

--- a/tests/test_spacetime.py
+++ b/tests/test_spacetime.py
@@ -36,7 +36,7 @@ events_data = [
 # distinct entity_id, event_date pairs
 state_data = sorted(list(product(
     set([l[0] for l in events_data]),
-    set([l[1] for l in events_data])
+    set([l[1] for l in events_data] + [date(2016, 1, 1)])
 )))
 
 
@@ -152,15 +152,15 @@ def test_basic_spacetime():
         assert rows[6]['as_of_date'] == date(2015, 1, 1)
         assert rows[6]['events_entity_id_1y_outcome::int_sum'] == 3
         assert rows[6]['events_entity_id_1y_outcome::int_sum_imp'] == 1
-        assert rows[6]['events_entity_id_1y_outcome::int_avg'] == 0.5/3.0
+        assert round(float(rows[6]['events_entity_id_1y_outcome::int_avg']), 4) == 0.1667
         assert rows[6]['events_entity_id_1y_outcome::int_avg_imp'] == 1
         assert rows[6]['events_entity_id_2y_outcome::int_sum'] == 3
         assert rows[6]['events_entity_id_2y_outcome::int_sum_imp'] == 1
-        assert rows[6]['events_entity_id_2y_outcome::int_avg'] == 1.0/3.0
+        assert round(float(rows[6]['events_entity_id_2y_outcome::int_avg']), 4) == 0.3333
         assert rows[6]['events_entity_id_2y_outcome::int_avg_imp'] == 1
         assert rows[6]['events_entity_id_all_outcome::int_sum'] == 3
         assert rows[6]['events_entity_id_all_outcome::int_sum_imp'] == 1
-        assert rows[6]['events_entity_id_all_outcome::int_avg'] == 1.0/3.0
+        assert round(float(rows[6]['events_entity_id_all_outcome::int_avg']), 4) == 0.3333
         assert rows[6]['events_entity_id_all_outcome::int_avg_imp'] == 1
         assert rows[7]['entity_id'] == 4
         assert rows[7]['as_of_date'] == date(2016, 1, 1)

--- a/tests/test_spacetime.py
+++ b/tests/test_spacetime.py
@@ -44,7 +44,7 @@ def test_basic_spacetime():
     with testing.postgresql.Postgresql() as psql:
         engine = sqlalchemy.create_engine(psql.url())
         engine.execute(
-            'create table events (entity_id int, date date, outcome bool)'
+            'create table events (entity_id int, event_date date, outcome bool)'
         )
         for event in events_data:
             engine.execute(
@@ -53,7 +53,7 @@ def test_basic_spacetime():
             )
 
         engine.execute(
-            'create table states (entity_id int, date date)'
+            'create table states (entity_id int, as_of_date date)'
         )
         for state in state_data:
             engine.execute(
@@ -75,15 +75,16 @@ def test_basic_spacetime():
                 dates = ['2016-01-01', '2015-01-01'],
                 state_table = 'states',
                 state_group = 'entity_id',
-                date_column = '"date"'
+                date_column = 'event_date',
+                output_date_column = 'as_of_date'
             )
 
         st.execute(engine.connect())
         
-        r = engine.execute('select * from events_entity_id order by entity_id, date')
+        r = engine.execute('select * from events_entity_id order by entity_id, as_of_date')
         rows = [x for x in r]
         assert rows[0]['entity_id'] == 1
-        assert rows[0]['date'] == date(2015, 1, 1)
+        assert rows[0]['as_of_date'] == date(2015, 1, 1)
         assert rows[0]['events_entity_id_1y_outcome::int_sum'] == 1
         assert rows[0]['events_entity_id_1y_outcome::int_avg'] == 0.5
         assert rows[0]['events_entity_id_2y_outcome::int_sum'] == 1
@@ -91,7 +92,7 @@ def test_basic_spacetime():
         assert rows[0]['events_entity_id_all_outcome::int_sum'] == 1
         assert rows[0]['events_entity_id_all_outcome::int_avg'] == 0.5
         assert rows[1]['entity_id'] == 1
-        assert rows[1]['date'] == date(2016, 1, 1)
+        assert rows[1]['as_of_date'] == date(2016, 1, 1)
         assert rows[1]['events_entity_id_1y_outcome::int_sum'] == 1
         assert rows[1]['events_entity_id_1y_outcome::int_avg'] == 0.5
         assert rows[1]['events_entity_id_2y_outcome::int_sum'] == 2
@@ -100,7 +101,7 @@ def test_basic_spacetime():
         assert rows[1]['events_entity_id_all_outcome::int_avg'] == 0.5
         
         assert rows[2]['entity_id'] == 2
-        assert rows[2]['date'] == date(2015, 1, 1)
+        assert rows[2]['as_of_date'] == date(2015, 1, 1)
         assert rows[2]['events_entity_id_1y_outcome::int_sum'] == 0
         assert rows[2]['events_entity_id_1y_outcome::int_avg'] == 0
         assert rows[2]['events_entity_id_2y_outcome::int_sum'] == 1
@@ -108,7 +109,7 @@ def test_basic_spacetime():
         assert rows[2]['events_entity_id_all_outcome::int_sum'] == 1
         assert rows[2]['events_entity_id_all_outcome::int_avg'] == 0.5
         assert rows[3]['entity_id'] == 2
-        assert rows[3]['date'] == date(2016, 1, 1)
+        assert rows[3]['as_of_date'] == date(2016, 1, 1)
         assert rows[3]['events_entity_id_1y_outcome::int_sum'] == None
         assert rows[3]['events_entity_id_1y_outcome::int_avg'] == None
         assert rows[3]['events_entity_id_2y_outcome::int_sum'] == 0
@@ -117,7 +118,7 @@ def test_basic_spacetime():
         assert rows[3]['events_entity_id_all_outcome::int_avg'] == 0.5
         
         assert rows[4]['entity_id'] == 3
-        assert rows[4]['date'] == date(2015, 1, 1)
+        assert rows[4]['as_of_date'] == date(2015, 1, 1)
         assert rows[4]['events_entity_id_1y_outcome::int_sum'] == 0
         assert rows[4]['events_entity_id_1y_outcome::int_avg'] == 0
         assert rows[4]['events_entity_id_2y_outcome::int_sum'] == 0
@@ -125,7 +126,7 @@ def test_basic_spacetime():
         assert rows[4]['events_entity_id_all_outcome::int_sum'] == 0
         assert rows[4]['events_entity_id_all_outcome::int_avg'] == 0
         assert rows[5]['entity_id'] == 3
-        assert rows[5]['date'] == date(2016, 1, 1)
+        assert rows[5]['as_of_date'] == date(2016, 1, 1)
         assert rows[5]['events_entity_id_1y_outcome::int_sum'] == 1
         assert rows[5]['events_entity_id_1y_outcome::int_avg'] == 0.5
         assert rows[5]['events_entity_id_2y_outcome::int_sum'] == 1
@@ -135,7 +136,7 @@ def test_basic_spacetime():
         
         assert rows[6]['entity_id'] == 4
         # rows[6]['date'] == date(2015, 1, 1) is skipped due to no data!
-        assert rows[6]['date'] == date(2016, 1, 1)
+        assert rows[6]['as_of_date'] == date(2016, 1, 1)
         assert rows[6]['events_entity_id_1y_outcome::int_sum'] == 0
         assert rows[6]['events_entity_id_1y_outcome::int_avg'] == 0
         assert rows[6]['events_entity_id_2y_outcome::int_sum'] == 0
@@ -145,10 +146,10 @@ def test_basic_spacetime():
         assert len(rows) == 7
 
         # check some imputation results
-        r = engine.execute('select * from events_aggregation_imputed order by entity_id, date')
+        r = engine.execute('select * from events_aggregation_imputed order by entity_id, as_of_date')
         rows = [x for x in r]
         assert rows[6]['entity_id'] == 4
-        assert rows[6]['date'] == date(2015, 1, 1)
+        assert rows[6]['as_of_date'] == date(2015, 1, 1)
         assert rows[6]['events_entity_id_1y_outcome::int_sum'] == 3
         assert rows[6]['events_entity_id_1y_outcome::int_sum_imp'] == 1
         assert rows[6]['events_entity_id_1y_outcome::int_avg'] == 0.5/3.0
@@ -162,7 +163,7 @@ def test_basic_spacetime():
         assert rows[6]['events_entity_id_all_outcome::int_avg'] == 1.0/3.0
         assert rows[6]['events_entity_id_all_outcome::int_avg_imp'] == 1
         assert rows[7]['entity_id'] == 4
-        assert rows[7]['date'] == date(2016, 1, 1)
+        assert rows[7]['as_of_date'] == date(2016, 1, 1)
         assert rows[7]['events_entity_id_1y_outcome::int_sum'] == 0
         assert rows[7]['events_entity_id_1y_outcome::int_sum_imp'] == 0
         assert rows[7]['events_entity_id_1y_outcome::int_avg'] == 0

--- a/tests/test_spacetime.py
+++ b/tests/test_spacetime.py
@@ -143,6 +143,40 @@ def test_basic_spacetime():
         assert rows[6]['events_entity_id_all_outcome::int_sum'] == 0
         assert rows[6]['events_entity_id_all_outcome::int_avg'] == 0
         assert len(rows) == 7
+
+        # check some imputation results
+        r = engine.execute('select * from events_aggregation_imputed order by entity_id, date')
+        rows = [x for x in r]
+        assert rows[6]['entity_id'] == 4
+        assert rows[6]['date'] == date(2015, 1, 1)
+        assert rows[6]['events_entity_id_1y_outcome::int_sum'] == 3
+        assert rows[6]['events_entity_id_1y_outcome::int_sum_imp'] == 1
+        assert rows[6]['events_entity_id_1y_outcome::int_avg'] == 0.5/3.0
+        assert rows[6]['events_entity_id_1y_outcome::int_avg_imp'] == 1
+        assert rows[6]['events_entity_id_2y_outcome::int_sum'] == 3
+        assert rows[6]['events_entity_id_2y_outcome::int_sum_imp'] == 1
+        assert rows[6]['events_entity_id_2y_outcome::int_avg'] == 1.0/3.0
+        assert rows[6]['events_entity_id_2y_outcome::int_avg_imp'] == 1
+        assert rows[6]['events_entity_id_all_outcome::int_sum'] == 3
+        assert rows[6]['events_entity_id_all_outcome::int_sum_imp'] == 1
+        assert rows[6]['events_entity_id_all_outcome::int_avg'] == 1.0/3.0
+        assert rows[6]['events_entity_id_all_outcome::int_avg_imp'] == 1
+        assert rows[7]['entity_id'] == 4
+        assert rows[7]['date'] == date(2016, 1, 1)
+        assert rows[7]['events_entity_id_1y_outcome::int_sum'] == 0
+        assert rows[7]['events_entity_id_1y_outcome::int_sum_imp'] == 0
+        assert rows[7]['events_entity_id_1y_outcome::int_avg'] == 0
+        assert rows[7]['events_entity_id_1y_outcome::int_avg_imp'] == 0
+        assert rows[7]['events_entity_id_2y_outcome::int_sum'] == 0
+        assert rows[7]['events_entity_id_2y_outcome::int_sum_imp'] == 0
+        assert rows[7]['events_entity_id_2y_outcome::int_avg'] == 0
+        assert rows[7]['events_entity_id_2y_outcome::int_avg_imp'] == 0
+        assert rows[7]['events_entity_id_all_outcome::int_sum'] == 0
+        assert rows[7]['events_entity_id_all_outcome::int_sum_imp'] == 0
+        assert rows[7]['events_entity_id_all_outcome::int_avg'] == 0
+        assert rows[7]['events_entity_id_all_outcome::int_avg_imp'] == 0
+        assert len(rows) == 8
+
         
 def test_input_min_date():
     with testing.postgresql.Postgresql() as psql:


### PR DESCRIPTION
Provides for a number of options for imputing null values, including mean imputation, constant value imputation, zero-filling, modal value for binaries, null categories for categoricals, and raising an exception when nulls are encountered (if data are expected to be clean).

A couple of notes:
* Specifying imputation rules is now required for using collate aggregates
* The aggregation objects now need to be passed a state table with a comprehensive set of entities and dates
* For aggregates, an "imputed" column is generated to flag NULL values that were filled; for categoricals, this is handled by including a NULL category
* Because the imputation code needs to both identify columns in the database containing NULL values as well as look up the imputation type from the column name, column name truncation will cause the code to break. This can be fixed by hashing column names and maintaining a lookup of full column names (potentially as well as human-readable versions)

In the future, we'll likely want to add additional imputation options (e.g., within-group mean, most frequent category for categoricals, most frequent pattern for categoricals, multiple imputation, etc.), but this will take a bit of extra work. Additionally, we may want to allow for overriding the generation of an imputed flag, for instance, in cases where zero-filling is meaningful (e.g., for count features created from a table of arrests, entities not in the table have no arrests, so 0 is in fact the correct value).