### PR TITLE
zero filling with no imputation flag (Closes #103)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -139,6 +139,7 @@ Currently available imputation rules:
     * ``mean``: The average value of the feature (for ``SpacetimeAggregation`` the mean is taken within-date).
     * ``constant``: Fill with a constant value from a required ``value`` parameter.
     * ``zero``: Fill with zero.
+    * ``zero_noflag``: Fill with zero without generating an "imputed" flag. This option should be used only for cases where null values are explicitly known to be zero such as absence of an entity from an events table indicating that no such event has occurred.
     * ``null_category``: Only available for categorical features. Just flag null values with the null category column.
     * ``binary_mode``: Only available for aggregate column types. Takes the modal value for a binary feature.
     * ``error``: Raise an exception if any null values are encountered for this feature.

--- a/collate/collate.py
+++ b/collate/collate.py
@@ -6,12 +6,13 @@ import re
 
 from .sql import make_sql_clause, to_sql_name, CreateTableAs, InsertFromSelect
 from .imputations import ImputeMean, ImputeConstant, ImputeZero, \
-    ImputeNullCategory, ImputeBinaryMode, ImputeError
+    ImputeZeroNoFlag, ImputeNullCategory, ImputeBinaryMode, ImputeError
 
 available_imputations = {
     'mean': ImputeMean,
     'constant': ImputeConstant,
     'zero': ImputeZero,
+    'zero_noflag': ImputeZeroNoFlag,
     'null_category': ImputeNullCategory,
     'binary_mode': ImputeBinaryMode,
     'error': ImputeError
@@ -610,7 +611,7 @@ class Aggregation(object):
                 imputer = imputer(column=col, partitionby=partitionby, **impute_rule)
 
                 query += '\n,%s' % imputer.to_sql()
-                if not imputer.catcol:
+                if not imputer.noflag:
                     # Add an imputation flag for non-categorical columns (this is handeled
                     # for categorical columns with a separate NULL category)
                     query += '\n,%s' % imputer.imputed_flag_sql()

--- a/tests/test_imputation_output.py
+++ b/tests/test_imputation_output.py
@@ -36,6 +36,10 @@ imputation_values = {
         'aggregate': {'avail': True, 'kwargs': {}},
         'categorical': {'avail': True, 'kwargs': {}}
     },
+    'zero_noflag': {
+        'aggregate': {'avail': True, 'kwargs': {}},
+        'categorical': {'avail': True, 'kwargs': {}}
+    },
     'null_category': {
         'aggregate': {'avail': False},
         'categorical': {'avail': True, 'kwargs': {}}
@@ -192,12 +196,12 @@ def _base_imputation_test(feat_list, exp_imp_cols, feat_table):
 
                     # for non-categoricals, should add an "imputed" column and be non-null
                     # (categoricals are expected to be handled through the null category)
-                    if feat in exp_imp_cols and coltype != 'categorical':
+                    # zero_noflag imputation should not generate a flag either
+                    if feat in exp_imp_cols and coltype != 'categorical' and imp != 'zero_noflag':
                         assert 'prefix_entity_id_1y_%s_max_imp' % feat in df.columns.values
                         assert df['prefix_entity_id_1y_%s_max_imp' % feat].isnull().sum() == 0
-
-                    # should not generate an imputed column when not needed
-                    if feat not in exp_imp_cols:
+                    else:
+                        # should not generate an imputed column when not needed
                         assert 'prefix_entity_id_1y_%s_max_imp' % feat not in df.columns.values
 
 def test_imputation_output():

--- a/tests/test_imputations.py
+++ b/tests/test_imputations.py
@@ -61,6 +61,21 @@ def test_impute_zero():
     imp = ImputeZero(column='a__NULL_mean', coltype='categorical')
     assert imp.to_sql() == 'COALESCE("a__NULL_mean", 1) AS "a__NULL_mean" '
 
+def test_impute_zero_noflag():
+    imp = ImputeZeroNoFlag(column='a', coltype='aggregate')
+    assert imp.to_sql() == 'COALESCE("a", 0) AS "a" '
+    assert imp.imputed_flag_sql() is None
+    assert imp.noflag
+
+    imp = ImputeZeroNoFlag(column='a_myval_max', coltype='categorical')
+    assert imp.to_sql() == 'COALESCE("a_myval_max", 0) AS "a_myval_max" '
+
+    imp = ImputeZeroNoFlag(column='a_otherval_max', coltype='categorical')
+    assert imp.to_sql() == 'COALESCE("a_otherval_max", 0) AS "a_otherval_max" '
+
+    imp = ImputeZeroNoFlag(column='a__NULL_mean', coltype='categorical')
+    assert imp.to_sql() == 'COALESCE("a__NULL_mean", 0) AS "a__NULL_mean" '
+
 def test_impute_null_cat():
     imp = ImputeNullCategory(column='a_myval_max', coltype='categorical')
     assert imp.to_sql() == 'COALESCE("a_myval_max", 0) AS "a_myval_max" '


### PR DESCRIPTION
Add an imputation option for zero-filling without generating an imputation flag, for cases where null values are explicitly known to be zero (for instance, when absence of an entity from an events table indicates that no such event has occurred).